### PR TITLE
Fix #73: Add pause status checks to activate_group, deactivate_group,…

### DIFF
--- a/contract/contracts/hello-world/src/autoshare_logic.rs
+++ b/contract/contracts/hello-world/src/autoshare_logic.rs
@@ -556,6 +556,10 @@ pub fn update_members(
 ) -> Result<(), Error> {
     caller.require_auth();
 
+    if get_paused_status(&env) {
+        return Err(Error::ContractPaused);
+    }
+
     let key = DataKey::AutoShare(id.clone());
     let mut details: AutoShareDetails = env
         .storage()
@@ -609,6 +613,10 @@ pub fn update_members(
 pub fn deactivate_group(env: Env, id: BytesN<32>, caller: Address) -> Result<(), Error> {
     caller.require_auth();
 
+    if get_paused_status(&env) {
+        return Err(Error::ContractPaused);
+    }
+
     let key = DataKey::AutoShare(id.clone());
     let mut details: AutoShareDetails = env
         .storage()
@@ -633,6 +641,10 @@ pub fn deactivate_group(env: Env, id: BytesN<32>, caller: Address) -> Result<(),
 
 pub fn activate_group(env: Env, id: BytesN<32>, caller: Address) -> Result<(), Error> {
     caller.require_auth();
+
+    if get_paused_status(&env) {
+        return Err(Error::ContractPaused);
+    }
 
     let key = DataKey::AutoShare(id.clone());
     let mut details: AutoShareDetails = env


### PR DESCRIPTION



This PR Added pause status checks to `activate_group`, `deactivate_group`, and `update_members` functions to ensure all state-mutating operations are blocked when the contract is paused.

## Changes
- Added `get_paused_status()` check to `activate_group` function
- Added `get_paused_status()` check to `deactivate_group` function  
- Added `get_paused_status()` check to `update_members` function

## Impact
- Ensures contract pause invariant is maintained across all state-changing operations
- Prevents group activation status modifications when contract is paused
- Maintains consistency with existing pause checks in `add_group_member`

## Testing
All three functions now follow the standard guard pattern:
1. Authentication check (`require_auth()`)
2. Pause status check (`get_paused_status()`)
3. Business logic

Closes #73
