### PR TITLE
fix: update CI workflows to use maintained actions

### DIFF
--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -33,10 +33,8 @@ jobs:
       # Set up Rust toolchain
       # -----------------------------
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       # -----------------------------

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -67,8 +67,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            node_modules
-            .next/cache
+            frontend/node_modules
+            frontend/.next/cache
           key: ${{ runner.os }}-deps-${{ hashFiles('frontend/package-lock.json', 'frontend/pnpm-lock.yaml', 'frontend/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-deps-


### PR DESCRIPTION
Closes #82

---

- Replace deprecated actions-rs/toolchain@v1 with dtolnay/rust-toolchain@stable
- Fix cache paths in frontend CI to use absolute paths from repo root
- Improve CI reliability and compatibility with latest GitHub Actions