### PR TITLE
feat: Fund distribution

### DIFF
--- a/contract/contracts/hello-world/src/autoshare_logic.rs
+++ b/contract/contracts/hello-world/src/autoshare_logic.rs
@@ -1,7 +1,7 @@
 use crate::base::errors::Error;
 use crate::base::events::{
     AdminTransferred, AutoshareCreated, AutoshareUpdated, ContractPaused, ContractUnpaused,
-    GroupActivated, GroupDeactivated, Withdrawal,
+    Distribution, GroupActivated, GroupDeactivated, Withdrawal,
 };
 use crate::base::types::{AutoShareDetails, GroupMember, PaymentHistory};
 use soroban_sdk::{contracttype, token, Address, BytesN, Env, String, Vec};
@@ -738,6 +738,76 @@ pub fn withdraw(
         recipient,
     }
     .publish(&env);
+    Ok(())
+}
+
+#[allow(clippy::needless_borrows_for_generic_args)]
+pub fn distribute(
+    env: Env,
+    id: BytesN<32>,
+    token: Address,
+    amount: i128,
+    sender: Address,
+) -> Result<(), Error> {
+    sender.require_auth();
+
+    if get_paused_status(&env) {
+        return Err(Error::ContractPaused);
+    }
+
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    if !is_token_supported(env.clone(), token.clone()) {
+        return Err(Error::UnsupportedToken);
+    }
+
+    let key = DataKey::AutoShare(id.clone());
+    let mut details: AutoShareDetails = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(Error::NotFound)?;
+
+    if !details.is_active {
+        return Err(Error::GroupInactive);
+    }
+
+    if details.usage_count == 0 {
+        return Err(Error::NoUsagesRemaining);
+    }
+
+    validate_members(&details.members)?;
+
+    let client = token::TokenClient::new(&env, &token);
+    client.transfer(&sender, &env.current_contract_address(), &amount);
+
+    let mut distributed: i128 = 0;
+    let members_len = details.members.len() as usize;
+    for (idx, member) in details.members.iter().enumerate() {
+        let share = if idx + 1 < members_len {
+            (amount * (member.percentage as i128)) / 100
+        } else {
+            amount - distributed
+        };
+        if share > 0 {
+            client.transfer(&env.current_contract_address(), &member.address, &share);
+            distributed += share;
+        }
+    }
+
+    details.usage_count -= 1;
+    env.storage().persistent().set(&key, &details);
+
+    Distribution {
+        id,
+        token,
+        sender,
+        amount,
+    }
+    .publish(&env);
+
     Ok(())
 }
 

--- a/contract/contracts/hello-world/src/base/events.rs
+++ b/contract/contracts/hello-world/src/base/events.rs
@@ -57,3 +57,15 @@ pub struct Withdrawal {
     pub recipient: Address,
     pub amount: i128,
 }
+
+#[contractevent(data_format = "single-value")]
+#[derive(Clone)]
+pub struct Distribution {
+    #[topic]
+    pub id: BytesN<32>,
+    #[topic]
+    pub token: Address,
+    #[topic]
+    pub sender: Address,
+    pub amount: i128,
+}

--- a/contract/contracts/hello-world/src/interfaces/autoshare.rs
+++ b/contract/contracts/hello-world/src/interfaces/autoshare.rs
@@ -96,6 +96,9 @@ pub trait AutoShareTrait {
     /// Checks if a token is supported.
     fn is_token_supported(env: Env, token: Address) -> bool;
 
+    /// Distributes a payment among group members based on their percentages.
+    fn distribute(env: Env, id: BytesN<32>, token: Address, amount: i128, sender: Address);
+
     // ============================================================================
     // Payment Configuration
     // ============================================================================

--- a/contract/contracts/hello-world/src/lib.rs
+++ b/contract/contracts/hello-world/src/lib.rs
@@ -165,6 +165,11 @@ impl AutoShareContract {
         autoshare_logic::is_token_supported(env, token)
     }
 
+    /// Distributes a payment among group members based on their percentages.
+    pub fn distribute(env: Env, id: BytesN<32>, token: Address, amount: i128, sender: Address) {
+        autoshare_logic::distribute(env, id, token, amount, sender).unwrap();
+    }
+
     // ============================================================================
     // Payment Configuration
     // ============================================================================
@@ -249,3 +254,7 @@ pub mod test_utils;
 #[cfg(test)]
 #[path = "tests/test_utils_test.rs"]
 mod test_utils_test;
+
+#[cfg(test)]
+#[path = "tests/distribute_test.rs"]
+mod distribute_test;

--- a/contract/contracts/hello-world/src/tests/distribute_test.rs
+++ b/contract/contracts/hello-world/src/tests/distribute_test.rs
@@ -1,0 +1,91 @@
+use super::test_utils::{assert_balance, create_test_group, mint_tokens, setup_test_env};
+use crate::base::types::GroupMember;
+use crate::mock_token::MockTokenClient;
+use crate::AutoShareContractClient;
+use soroban_sdk::{testutils::Address as _, Address, Vec};
+
+#[test]
+fn test_distribute_splits_payment_and_decrements_usage() {
+    let test_env = setup_test_env();
+    let env = test_env.env;
+    let contract = test_env.autoshare_contract;
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let client = AutoShareContractClient::new(&env, &contract);
+
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let member3 = Address::generate(&env);
+
+    let mut members = Vec::new(&env);
+    members.push_back(GroupMember {
+        address: member1.clone(),
+        percentage: 50,
+    });
+    members.push_back(GroupMember {
+        address: member2.clone(),
+        percentage: 30,
+    });
+    members.push_back(GroupMember {
+        address: member3.clone(),
+        percentage: 20,
+    });
+
+    let creator = test_env.users.get(0).unwrap().clone();
+    let usages = 2u32;
+    let id = create_test_group(&env, &contract, &creator, &members, usages, &token);
+
+    let sender = test_env.users.get(1).unwrap().clone();
+    let amount: i128 = 1000;
+
+    mint_tokens(&env, &token, &sender, amount);
+
+    let token_client = MockTokenClient::new(&env, &token);
+    let sender_start = token_client.balance(&sender);
+
+    client.distribute(&id, &token, &amount, &sender);
+
+    // Verify member balances
+    assert_balance(&env, &token, &member1, 500);
+    assert_balance(&env, &token, &member2, 300);
+    assert_balance(&env, &token, &member3, 200);
+
+    // Verify sender paid the amount
+    let sender_end = token_client.balance(&sender);
+    assert_eq!(sender_start - amount, sender_end);
+
+    // Verify remaining usages decremented
+    let remaining = client.get_remaining_usages(&id);
+    assert_eq!(remaining, usages - 1);
+}
+
+#[test]
+#[should_panic]
+fn test_distribute_fails_when_group_inactive() {
+    let test_env = setup_test_env();
+    let env = test_env.env;
+    let contract = test_env.autoshare_contract;
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let client = AutoShareContractClient::new(&env, &contract);
+
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+
+    let mut members = Vec::new(&env);
+    members.push_back(GroupMember {
+        address: member1.clone(),
+        percentage: 60,
+    });
+    members.push_back(GroupMember {
+        address: member2.clone(),
+        percentage: 40,
+    });
+
+    let creator = test_env.users.get(0).unwrap().clone();
+    let id = create_test_group(&env, &contract, &creator, &members, 1u32, &token);
+
+    client.deactivate_group(&id, &creator);
+
+    let sender = test_env.users.get(1).unwrap().clone();
+    mint_tokens(&env, &token, &sender, 500);
+    client.distribute(&id, &token, &500, &sender);
+}


### PR DESCRIPTION
## Add `distribute` Function for AutoShare Group Payments

### Summary
This PR implements a `distribute` function that enables proportional payment splitting among AutoShare group members in a single on-chain transaction, along with a corresponding `Distribution` event and test coverage.

---

Closes #61 
### What's Changed

**Core Logic — `autoshare_logic.rs`**
- Added `distribute(env, id, token, amount, sender)` which:
  - Validates contract is not paused, amount is positive, and token is supported
  - Loads the AutoShare group and checks it's active with usages remaining
  - Transfers the full `amount` from `sender` into the contract
  - Iterates members and splits proportionally by `percentage`; the last member receives the remainder to avoid rounding loss
  - Decrements `usage_count` and persists updated state
  - Emits a `Distribution` event

**Event — `events.rs`**
- Added `Distribution` event struct with `id`, `token`, and `sender` as topics and `amount` as data

**Interface — `autoshare.rs`**
- Added `distribute` to the `AutoShareTrait` interface with inline documentation

**Contract Entry — `lib.rs`**
- Exposed `distribute` as a public contract function, delegating to `autoshare_logic::distribute`
- Registered `distribute_test` module under `#[cfg(test)]`

**Tests — `distribute_test.rs`**
- `test_distribute_splits_payment_and_decrements_usage` — mints tokens to sender, calls `distribute` with a 3-member group (50/30/20 split), asserts exact member balances, verifies sender balance reduced by full amount, and confirms `usage_count` decremented
- `test_distribute_fails_when_group_inactive` — deactivates a group then asserts `distribute` panics with `GroupInactive`

---

### Guards & Validations
| Condition | Error |
|---|---|
| Contract paused | `ContractPaused` |
| `amount <= 0` | `InvalidAmount` |
| Token not supported | `UnsupportedToken` |
| Group not found | `NotFound` |
| Group inactive | `GroupInactive` |
| No usages remaining | `NoUsagesRemaining` |
| Empty members list | `EmptyMembers` |

---

### Notes
- Rounding handled by giving the last member the residual (`amount - distributed`) to guarantee the full amount is always distributed with no dust left in the contract
- `#[allow(clippy::needless_borrows_for_generic_args)]` added to suppress a false-positive lint on the token client call

---

### Checklist
- [x] Core `distribute` logic implemented
- [x] `Distribution` event added
- [x] Interface updated
- [x] Public contract entrypoint exposed
- [x] Happy path test with balance and usage assertions
- [x] Negative test for inactive group
- [ ] Additional edge cases (zero usages, unsupported token, paused contract) — can follow up in a separate PR