### PR TITLE
fix: remove unauthorized reduce_usage function exposure

### DIFF
--- a/contract/contracts/hello-world/src/autoshare_logic.rs
+++ b/contract/contracts/hello-world/src/autoshare_logic.rs
@@ -1,7 +1,7 @@
 use crate::base::errors::Error;
 use crate::base::events::{
     AdminTransferred, AutoshareCreated, AutoshareUpdated, ContractPaused, ContractUnpaused,
-    Distribution, GroupActivated, GroupDeactivated, Withdrawal,
+    Distribution, GroupActivated, GroupDeactivated, GroupDeleted, Withdrawal,
 };
 use crate::base::types::{AutoShareDetails, GroupMember, PaymentHistory};
 use soroban_sdk::{contracttype, token, Address, BytesN, Env, String, Vec};
@@ -622,6 +622,8 @@ pub fn get_total_usages_paid(env: Env, id: BytesN<32>) -> Result<u32, Error> {
     Ok(details.total_usages_paid)
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 pub fn reduce_usage(env: Env, id: BytesN<32>) -> Result<(), Error> {
     let key = DataKey::AutoShare(id);
     let mut details: AutoShareDetails = env
@@ -834,7 +836,7 @@ pub fn delete_group(env: Env, id: BytesN<32>, caller: Address) -> Result<(), Err
     if details.usage_count > 0 {
         // Option 1: Strict enforcement - uncomment to require zero usages
         // return Err(Error::GroupHasRemainingUsages);
-        
+
         // Option 2: Allow deletion with forfeiture (current implementation)
         // The remaining usages are simply forfeited
     }

--- a/contract/contracts/hello-world/src/base/errors.rs
+++ b/contract/contracts/hello-world/src/base/errors.rs
@@ -26,4 +26,5 @@ pub enum Error {
     GroupAlreadyInactive = 20,
     InsufficientContractBalance = 21,
     MemberNotFound = 22,
+    GroupNotDeactivated = 23,
 }

--- a/contract/contracts/hello-world/src/base/events.rs
+++ b/contract/contracts/hello-world/src/base/events.rs
@@ -69,3 +69,11 @@ pub struct Distribution {
     pub sender: Address,
     pub amount: i128,
 }
+
+#[contractevent(data_format = "single-value")]
+#[derive(Clone)]
+pub struct GroupDeleted {
+    #[topic]
+    pub deleter: Address,
+    pub id: BytesN<32>,
+}

--- a/contract/contracts/hello-world/src/interfaces/autoshare.rs
+++ b/contract/contracts/hello-world/src/interfaces/autoshare.rs
@@ -156,7 +156,4 @@ pub trait AutoShareTrait {
 
     /// Returns the total usages paid for a group.
     fn get_total_usages_paid(env: Env, id: BytesN<32>) -> u32;
-
-    /// Reduces the usage count by 1 (dummy function for testing).
-    fn reduce_usage(env: Env, id: BytesN<32>);
 }

--- a/contract/contracts/hello-world/src/lib.rs
+++ b/contract/contracts/hello-world/src/lib.rs
@@ -246,11 +246,6 @@ impl AutoShareContract {
     pub fn get_total_usages_paid(env: Env, id: BytesN<32>) -> u32 {
         autoshare_logic::get_total_usages_paid(env, id).unwrap()
     }
-
-    /// Reduces the usage count by 1 (dummy function for testing).
-    pub fn reduce_usage(env: Env, id: BytesN<32>) {
-        autoshare_logic::reduce_usage(env, id).unwrap();
-    }
 }
 
 // 3. Link the tests (Requirement: Unit Tests)


### PR DESCRIPTION
close #63 


- Remove reduce_usage from public contract interface
- Restrict function to test builds only with #[cfg(test)]
- Add missing GroupNotDeactivated error variant
- Add missing GroupDeleted event struct




