### PR TITLE
docs: add global state management spec

### DIFF
--- a/Documents/Stellar-save/.kiro/specs/global-state-management/.config.kiro
+++ b/Documents/Stellar-save/.kiro/specs/global-state-management/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "9b0b2bc7-85ae-43a9-82aa-1481a7be8c99", "workflowType": "requirements-first", "specType": "feature"}

--- a/Documents/Stellar-save/.kiro/specs/global-state-management/design.md
+++ b/Documents/Stellar-save/.kiro/specs/global-state-management/design.md
@@ -1,0 +1,576 @@
+# Design Document: Global State Management
+
+## Overview
+
+This design document specifies the implementation of a global state management solution for the Stellar-Save frontend application. The solution will use Zustand as the state management library, providing a lightweight, TypeScript-friendly approach to managing application-wide state including UI preferences and user settings.
+
+### Design Goals
+
+- Implement a centralized state management solution that coexists with the existing WalletProvider
+- Provide type-safe state access and mutations throughout the application
+- Enable state persistence across browser sessions for user preferences
+- Support efficient debugging and development workflows
+- Maintain minimal bundle size impact (< 5KB gzipped)
+- Ensure optimal rendering performance through selective subscriptions
+
+### Solution Selection: Zustand
+
+After evaluating Redux Toolkit, Context API, and Zustand against the requirements, Zustand is selected for the following reasons:
+
+1. **Minimal Bundle Size**: Zustand core is ~1.2KB gzipped, well under the 5KB requirement
+2. **TypeScript Excellence**: First-class TypeScript support with full type inference
+3. **Simple API**: Hooks-based API with minimal boilerplate compared to Redux
+4. **Built-in DevTools**: Native Redux DevTools integration for debugging
+5. **Middleware Ecosystem**: Built-in persistence and immer middleware
+6. **No Provider Wrapping**: Can be used without wrapping the component tree, avoiding conflicts with WalletProvider
+7. **Selective Subscriptions**: Components only re-render when their selected state changes
+8. **Testing Support**: Easy to create isolated store instances for testing
+
+### Architecture Principles
+
+- **Separation of Concerns**: Wallet state remains in WalletProvider; application state moves to Zustand
+- **Domain-Driven Slices**: State organized by domain (UI, user preferences) for maintainability
+- **Immutable Updates**: All state modifications use immutable patterns (via immer middleware)
+- **Persistence Strategy**: User preferences persist to localStorage; UI state to sessionStorage
+- **Type Safety First**: Full TypeScript coverage with no `any` types in store definitions
+
+## Architecture
+
+### High-Level Architecture
+
+```mermaid
+graph TD
+    A[React Component Tree] --> B[AppThemeProvider]
+    B --> C[WalletProvider]
+    C --> D[App Components]
+    D --> E[Zustand Store]
+    E --> F[UI State Slice]
+    E --> G[User Preferences Slice]
+    F --> H[sessionStorage]
+    G --> I[localStorage]
+    E --> J[Redux DevTools]
+```
+
+### State Management Layers
+
+1. **Wallet Layer** (Existing): WalletProvider manages wallet-specific state
+   - Connection status, active address, network, connected accounts
+   - Remains unchanged, uses Context API
+
+2. **Application Layer** (New): Zustand store manages application state
+   - UI state (sidebar, modals, view modes)
+   - User preferences (language, currency, notifications)
+   - No provider wrapping required
+
+3. **Persistence Layer**: Middleware handles storage
+   - localStorage for user preferences (long-term)
+   - sessionStorage for UI state (session-only)
+
+### Store Organization
+
+The Zustand store will be organized into slices using a combined store pattern:
+
+```
+store/
+├── index.ts              # Store creation and exports
+├── slices/
+│   ├── uiSlice.ts       # UI state slice
+│   └── preferencesSlice.ts  # User preferences slice
+├── middleware/
+│   └── persistence.ts   # Custom persistence middleware
+├── types.ts             # TypeScript type definitions
+└── testUtils.ts         # Testing utilities
+```
+
+## Components and Interfaces
+
+### Store Structure
+
+The store combines multiple slices into a single store instance:
+
+```typescript
+interface AppStore {
+  // UI State Slice
+  ui: {
+    sidebarOpen: boolean;
+    activeModal: string | null;
+    viewMode: 'grid' | 'list';
+    theme: 'light' | 'dark' | 'system';
+  };
+  
+  // UI Actions
+  toggleSidebar: () => void;
+  openModal: (modalId: string) => void;
+  closeModal: () => void;
+  setViewMode: (mode: 'grid' | 'list') => void;
+  setTheme: (theme: 'light' | 'dark' | 'system') => void;
+  
+  // User Preferences Slice
+  preferences: {
+    language: string;
+    currencyDisplay: 'code' | 'symbol';
+    notificationsEnabled: boolean;
+    soundEnabled: boolean;
+  };
+  
+  // Preference Actions
+  setLanguage: (language: string) => void;
+  setCurrencyDisplay: (display: 'code' | 'symbol') => void;
+  toggleNotifications: () => void;
+  toggleSound: () => void;
+  resetPreferences: () => void;
+}
+```
+
+### UI State Slice
+
+**Purpose**: Manages ephemeral UI state that should persist only during the current session.
+
+**State Shape**:
+```typescript
+interface UIState {
+  sidebarOpen: boolean;
+  activeModal: string | null;
+  viewMode: 'grid' | 'list';
+  theme: 'light' | 'dark' | 'system';
+}
+```
+
+**Actions**:
+- `toggleSidebar()`: Toggles sidebar open/closed state
+- `openModal(modalId: string)`: Opens a modal by ID
+- `closeModal()`: Closes the currently active modal
+- `setViewMode(mode)`: Sets the view mode for list displays
+- `setTheme(theme)`: Sets the application theme preference
+
+**Persistence**: sessionStorage (cleared on browser close)
+
+### User Preferences Slice
+
+**Purpose**: Manages user preferences that should persist across sessions.
+
+**State Shape**:
+```typescript
+interface PreferencesState {
+  language: string;
+  currencyDisplay: 'code' | 'symbol';
+  notificationsEnabled: boolean;
+  soundEnabled: boolean;
+}
+```
+
+**Actions**:
+- `setLanguage(language)`: Updates the user's language preference
+- `setCurrencyDisplay(display)`: Sets currency display format
+- `toggleNotifications()`: Toggles notification preferences
+- `toggleSound()`: Toggles sound effects
+- `resetPreferences()`: Resets all preferences to defaults
+
+**Persistence**: localStorage (persists indefinitely)
+
+### Custom Hooks
+
+The store will expose domain-specific hooks for component consumption:
+
+```typescript
+// Hook for UI state
+function useUIState(): UIState & UIActions;
+function useUIState<T>(selector: (state: UIState) => T): T;
+
+// Hook for preferences
+function usePreferences(): PreferencesState & PreferencesActions;
+function usePreferences<T>(selector: (state: PreferencesState) => T): T;
+
+// Hook for full store (use sparingly)
+function useAppStore(): AppStore;
+function useAppStore<T>(selector: (state: AppStore) => T): T;
+```
+
+### Integration with Existing Architecture
+
+**WalletProvider Coexistence**:
+- WalletProvider continues to manage wallet state via Context API
+- Zustand store operates independently without provider wrapping
+- No modifications required to WalletProvider or useWallet hook
+- Both can be used simultaneously in components
+
+**Component Usage Pattern**:
+```typescript
+function MyComponent() {
+  // Wallet state (existing pattern)
+  const { activeAddress, connect } = useWallet();
+  
+  // Application state (new pattern)
+  const sidebarOpen = useUIState(state => state.sidebarOpen);
+  const toggleSidebar = useUIState(state => state.toggleSidebar);
+  
+  // Both work together seamlessly
+}
+```
+
+## Data Models
+
+### Store State Type Definitions
+
+```typescript
+// Core state types
+type ViewMode = 'grid' | 'list';
+type Theme = 'light' | 'dark' | 'system';
+type CurrencyDisplay = 'code' | 'symbol';
+
+// UI State
+interface UIState {
+  sidebarOpen: boolean;
+  activeModal: string | null;
+  viewMode: ViewMode;
+  theme: Theme;
+}
+
+// User Preferences
+interface PreferencesState {
+  language: string;
+  currencyDisplay: CurrencyDisplay;
+  notificationsEnabled: boolean;
+  soundEnabled: boolean;
+}
+
+// Combined store state
+interface AppStoreState {
+  ui: UIState;
+  preferences: PreferencesState;
+}
+
+// Action types
+interface UIActions {
+  toggleSidebar: () => void;
+  openModal: (modalId: string) => void;
+  closeModal: () => void;
+  setViewMode: (mode: ViewMode) => void;
+  setTheme: (theme: Theme) => void;
+}
+
+interface PreferencesActions {
+  setLanguage: (language: string) => void;
+  setCurrencyDisplay: (display: CurrencyDisplay) => void;
+  toggleNotifications: () => void;
+  toggleSound: () => void;
+  resetPreferences: () => void;
+}
+
+// Full store type
+type AppStore = AppStoreState & UIActions & PreferencesActions;
+```
+
+### Default State Values
+
+```typescript
+const DEFAULT_UI_STATE: UIState = {
+  sidebarOpen: true,
+  activeModal: null,
+  viewMode: 'grid',
+  theme: 'system',
+};
+
+const DEFAULT_PREFERENCES: PreferencesState = {
+  language: 'en',
+  currencyDisplay: 'code',
+  notificationsEnabled: true,
+  soundEnabled: true,
+};
+```
+
+### Persistence Configuration
+
+```typescript
+interface PersistenceConfig {
+  name: string;              // Storage key
+  storage: Storage;          // localStorage or sessionStorage
+  partialize?: (state: AppStore) => Partial<AppStore>;  // Select what to persist
+  version?: number;          // Schema version for migrations
+  migrate?: (persistedState: unknown, version: number) => AppStore;
+}
+
+// UI state persistence (sessionStorage)
+const uiPersistConfig: PersistenceConfig = {
+  name: 'stellar-save-ui',
+  storage: sessionStorage,
+  partialize: (state) => ({ ui: state.ui }),
+};
+
+// Preferences persistence (localStorage)
+const preferencesPersistConfig: PersistenceConfig = {
+  name: 'stellar-save-preferences',
+  storage: localStorage,
+  partialize: (state) => ({ preferences: state.preferences }),
+  version: 1,
+};
+```
+
+### Storage Schema
+
+**sessionStorage key**: `stellar-save-ui`
+```json
+{
+  "state": {
+    "ui": {
+      "sidebarOpen": true,
+      "activeModal": null,
+      "viewMode": "grid",
+      "theme": "system"
+    }
+  },
+  "version": 0
+}
+```
+
+**localStorage key**: `stellar-save-preferences`
+```json
+{
+  "state": {
+    "preferences": {
+      "language": "en",
+      "currencyDisplay": "code",
+      "notificationsEnabled": true,
+      "soundEnabled": true
+    }
+  },
+  "version": 1
+}
+```
+
+
+## Correctness Properties
+
+A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.
+
+### Property 1: Immutable State Updates
+
+For any state in the store and any action that modifies that state, calling the action should not mutate the previous state object—the previous state should remain unchanged and a new state object should be created.
+
+**Validates: Requirements 2.6, 3.4**
+
+### Property 2: Preferences Persistence to localStorage
+
+For any user preference update (language, currency display, notifications, sound), after the action completes, localStorage should contain the updated preference value under the key 'stellar-save-preferences'.
+
+**Validates: Requirements 4.1**
+
+### Property 3: UI State Persistence to sessionStorage
+
+For any UI state update (sidebar, modal, view mode, theme), after the action completes, sessionStorage should contain the updated UI state value under the key 'stellar-save-ui'.
+
+**Validates: Requirements 4.2**
+
+### Property 4: Persistence Serialization Format
+
+For any persisted state in localStorage or sessionStorage, the stored value should be valid JSON that can be parsed without errors.
+
+**Validates: Requirements 4.5**
+
+### Property 5: Persistence Round-Trip
+
+For any valid store state, persisting the state to storage and then hydrating from that storage should produce an equivalent state object with all values preserved.
+
+**Validates: Requirements 4.7**
+
+### Property 6: Selective Re-rendering
+
+For any component subscribed to a specific state slice, when state in a different slice changes, the component should not re-render—components should only re-render when their selected state changes.
+
+**Validates: Requirements 6.5, 7.1**
+
+### Property 7: Selector Memoization
+
+For any derived state selector with expensive computation, when called multiple times with the same input state, the selector should return the same memoized result without recomputing, reducing unnecessary calculations.
+
+**Validates: Requirements 7.3**
+
+### Property 8: Batched State Updates
+
+For any sequence of multiple synchronous state updates, the store should batch them into a single render cycle, resulting in only one component re-render rather than multiple re-renders.
+
+**Validates: Requirements 7.4**
+
+## Error Handling
+
+### Storage Errors
+
+**Corrupted Data Handling**:
+- When hydrating from storage, if JSON parsing fails, the store will catch the error
+- Default state values will be used instead of corrupted data
+- A warning will be logged to the console with details about the corruption
+- The corrupted storage entry will be cleared to prevent repeated errors
+
+**Storage Quota Exceeded**:
+- When persisting state, if storage quota is exceeded, the error will be caught
+- The operation will fail silently to prevent application crashes
+- An error will be logged to the console
+- The application will continue functioning with in-memory state only
+
+**Storage Unavailable**:
+- If localStorage or sessionStorage is unavailable (private browsing, disabled)
+- The store will detect this during initialization
+- Persistence will be disabled gracefully
+- The application will function normally with in-memory state only
+- A warning will be logged once during initialization
+
+### Action Errors
+
+**Invalid Action Parameters**:
+- TypeScript will prevent invalid parameters at compile time
+- Runtime validation is not performed for performance reasons
+- Developers should rely on TypeScript for parameter validation
+
+**State Update Failures**:
+- Zustand's immer middleware ensures state updates are atomic
+- If an update throws an error, the state remains unchanged
+- Errors will propagate to the calling component
+- Components should use error boundaries to handle update failures
+
+### Hydration Errors
+
+**Version Mismatch**:
+- If persisted state version doesn't match current version
+- Migration function will be called to transform old state to new format
+- If migration fails, default state will be used
+- A warning will be logged about the migration failure
+
+**Missing Required Fields**:
+- If hydrated state is missing required fields
+- Default values will be merged with hydrated state
+- Partial hydration will succeed with defaults for missing fields
+- No error will be thrown, ensuring graceful degradation
+
+### DevTools Errors
+
+**DevTools Connection Failure**:
+- If Redux DevTools extension is not installed
+- The store will function normally without devtools
+- No error will be thrown or logged
+- Devtools middleware will be a no-op in production
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+The global state management implementation will use both unit testing and property-based testing to ensure comprehensive coverage:
+
+**Unit Tests**: Focus on specific examples, edge cases, and error conditions
+- Specific action behaviors (e.g., toggling sidebar opens/closes correctly)
+- Edge cases (e.g., corrupted storage data, missing fields)
+- Error conditions (e.g., storage quota exceeded, unavailable storage)
+- Integration with React components
+- DevTools configuration in different environments
+
+**Property Tests**: Verify universal properties across all inputs
+- Immutability of state updates across all actions
+- Persistence round-trips for all state shapes
+- Selective re-rendering for all state slices
+- Batching behavior for all update sequences
+- Memoization for all selectors
+
+Together, unit tests catch concrete bugs in specific scenarios, while property tests verify general correctness across the entire input space.
+
+### Property-Based Testing Configuration
+
+**Library Selection**: We will use `@fast-check/vitest` for property-based testing, which integrates seamlessly with our existing Vitest test setup.
+
+**Test Configuration**:
+- Each property test will run a minimum of 100 iterations to ensure comprehensive input coverage
+- Tests will use fast-check's built-in generators for primitives and custom generators for domain types
+- Each property test will include a comment tag referencing its design document property
+
+**Tag Format**:
+```typescript
+// Feature: global-state-management, Property 1: Immutable State Updates
+test.prop([fc.record({...})])('state updates are immutable', (initialState) => {
+  // Test implementation
+});
+```
+
+**Property Test Coverage**:
+1. Property 1 (Immutability): Generate random initial states and random actions, verify previous state unchanged
+2. Property 2 (Preferences Persistence): Generate random preference values, verify localStorage contains them
+3. Property 3 (UI Persistence): Generate random UI states, verify sessionStorage contains them
+4. Property 4 (JSON Format): Generate random states, verify stored values are valid JSON
+5. Property 5 (Round-Trip): Generate random states, verify persist→hydrate preserves values
+6. Property 6 (Selective Rendering): Generate random state changes, verify only subscribed components render
+7. Property 7 (Memoization): Generate random states, verify selectors don't recompute unnecessarily
+8. Property 8 (Batching): Generate random update sequences, verify single render cycle
+
+### Unit Test Coverage
+
+**Store Creation and Initialization**:
+- Store initializes with correct default values
+- Store structure includes all required slices
+- Custom hooks are exported and accessible
+
+**UI State Actions**:
+- `toggleSidebar()` toggles between true/false
+- `openModal(id)` sets activeModal to the provided id
+- `closeModal()` sets activeModal to null
+- `setViewMode(mode)` updates viewMode
+- `setTheme(theme)` updates theme
+
+**Preferences Actions**:
+- `setLanguage(lang)` updates language
+- `setCurrencyDisplay(display)` updates currency display
+- `toggleNotifications()` toggles notifications
+- `toggleSound()` toggles sound
+- `resetPreferences()` restores all defaults
+
+**Persistence Behavior**:
+- Preferences save to localStorage on update
+- UI state saves to sessionStorage on update
+- Store hydrates from storage on initialization
+- Corrupted storage data falls back to defaults
+- Missing storage fields merge with defaults
+
+**Error Handling**:
+- Storage quota exceeded handled gracefully
+- Storage unavailable handled gracefully
+- Invalid JSON in storage handled gracefully
+- Version mismatch triggers migration
+
+**DevTools Integration**:
+- DevTools enabled in development environment
+- DevTools disabled in production environment
+- DevTools connection failure doesn't break store
+
+**React Integration**:
+- Components using useUIState re-render on UI state changes
+- Components using usePreferences re-render on preference changes
+- Components don't re-render on unrelated state changes
+- Multiple components can subscribe to same state
+- Store works alongside WalletProvider without conflicts
+
+**Testing Utilities**:
+- `createTestStore()` creates isolated store instances
+- Test store accepts custom initial state
+- Test store works with React Testing Library
+- Actions can be spied on in tests
+- State can be mocked for component tests
+
+### Test File Organization
+
+```
+src/store/
+├── __tests__/
+│   ├── store.test.ts              # Store creation and structure
+│   ├── uiSlice.test.ts            # UI state actions
+│   ├── preferencesSlice.test.ts   # Preferences actions
+│   ├── persistence.test.ts        # Persistence behavior
+│   ├── integration.test.tsx       # React integration
+│   └── properties.test.ts         # Property-based tests
+└── testUtils.ts                   # Testing utilities
+```
+
+### Integration with Existing Tests
+
+The new state management tests will follow the existing test patterns in the Stellar-Save frontend:
+- Use Vitest as the test runner (already configured)
+- Use React Testing Library for component tests (already in use)
+- Follow existing test file naming conventions (`*.test.ts`, `*.test.tsx`)
+- Use the existing test setup in `src/test/setup.ts`
+- Maintain similar test structure and assertions as existing component tests
+

--- a/Documents/Stellar-save/.kiro/specs/global-state-management/requirements.md
+++ b/Documents/Stellar-save/.kiro/specs/global-state-management/requirements.md
@@ -1,0 +1,144 @@
+# Requirements Document
+
+## Introduction
+
+This document defines the requirements for implementing a global state management solution in the Stellar-Save frontend application. The application currently uses Context API for wallet state (WalletProvider) and needs a comprehensive solution for managing application-wide state including UI state, user preferences, and other global concerns. The solution must be lightweight, TypeScript-friendly, and integrate seamlessly with the existing React architecture.
+
+## Glossary
+
+- **State_Manager**: The chosen state management library and its configuration (Zustand, Redux Toolkit, or Context API)
+- **Store**: The centralized state container that holds application state
+- **State_Slice**: A logical partition of the store representing a specific domain (e.g., UI state, user preferences)
+- **Persistence_Layer**: The mechanism for saving and restoring state to/from browser storage
+- **Dev_Tools**: Browser extensions and debugging utilities for inspecting state changes
+- **Selector**: A function that extracts specific data from the store
+- **Action**: A function that modifies state in the store
+- **Hydration**: The process of restoring persisted state when the application initializes
+- **WalletProvider**: The existing Context API provider for wallet-specific state (connection, accounts, network)
+- **Application_State**: Non-wallet global state including UI preferences, theme settings, and user configurations
+
+## Requirements
+
+### Requirement 1: State Management Solution Selection
+
+**User Story:** As a developer, I want to select an appropriate state management solution, so that the application has a maintainable and performant approach to global state.
+
+#### Acceptance Criteria
+
+1. THE State_Manager SHALL be one of: Zustand, Redux Toolkit, or enhanced Context API
+2. THE State_Manager SHALL support TypeScript with full type inference
+3. THE State_Manager SHALL have a bundle size under 5KB (gzipped) for the core library
+4. THE State_Manager SHALL integrate with React DevTools or provide equivalent debugging capabilities
+5. THE State_Manager SHALL coexist with the existing WalletProvider without conflicts
+
+### Requirement 2: Store Structure and Organization
+
+**User Story:** As a developer, I want a well-organized store structure, so that state is maintainable and scalable as the application grows.
+
+#### Acceptance Criteria
+
+1. THE Store SHALL be organized into separate State_Slices by domain
+2. THE Store SHALL include a UI_State_Slice for interface preferences (sidebar state, modal visibility, view modes)
+3. THE Store SHALL include a User_Preferences_Slice for user settings (language, currency display, notification preferences)
+4. THE Store SHALL provide type-safe Selectors for accessing state
+5. THE Store SHALL provide type-safe Actions for modifying state
+6. WHEN a State_Slice is created, THE Store SHALL enforce immutable state updates
+
+### Requirement 3: State Slice Implementation
+
+**User Story:** As a developer, I want to create state slices with clear patterns, so that adding new state domains is consistent and straightforward.
+
+#### Acceptance Criteria
+
+1. THE State_Slice SHALL define its initial state with TypeScript types
+2. THE State_Slice SHALL expose Actions for all state modifications
+3. THE State_Slice SHALL expose Selectors for accessing state values
+4. WHEN an Action is called, THE State_Slice SHALL update state immutably
+5. THE State_Slice SHALL include unit tests verifying state transitions
+
+### Requirement 4: State Persistence
+
+**User Story:** As a user, I want my preferences to persist across sessions, so that I don't have to reconfigure the application each time I visit.
+
+#### Acceptance Criteria
+
+1. THE Persistence_Layer SHALL save User_Preferences_Slice to localStorage
+2. THE Persistence_Layer SHALL save UI_State_Slice to sessionStorage
+3. WHEN the application initializes, THE Persistence_Layer SHALL perform Hydration from storage
+4. WHEN Hydration fails due to corrupted data, THE Persistence_Layer SHALL use default state and log a warning
+5. THE Persistence_Layer SHALL serialize state to JSON format
+6. THE Persistence_Layer SHALL deserialize JSON to typed state objects
+7. FOR ALL valid state objects, serializing then deserializing SHALL produce an equivalent state object (round-trip property)
+
+### Requirement 5: Development Tools Integration
+
+**User Story:** As a developer, I want debugging tools for state management, so that I can inspect state changes and diagnose issues efficiently.
+
+#### Acceptance Criteria
+
+1. WHERE the environment is development, THE Dev_Tools SHALL be enabled
+2. WHERE the environment is production, THE Dev_Tools SHALL be disabled
+3. THE Dev_Tools SHALL display current state values
+4. THE Dev_Tools SHALL display state change history
+5. WHEN an Action is dispatched, THE Dev_Tools SHALL log the action name and payload
+6. THE Dev_Tools SHALL support time-travel debugging (if supported by State_Manager)
+
+### Requirement 6: Store Provider Integration
+
+**User Story:** As a developer, I want the store to integrate cleanly with the React component tree, so that components can access state without prop drilling.
+
+#### Acceptance Criteria
+
+1. THE Store SHALL be provided to the component tree via a React provider component
+2. THE Store provider SHALL be positioned in the component tree to wrap all components needing Application_State
+3. THE Store provider SHALL not wrap or interfere with the existing WalletProvider
+4. THE Application SHALL provide custom hooks for accessing state (e.g., useUIState, useUserPreferences)
+5. WHEN a component uses a state hook, THE component SHALL re-render only when selected state changes
+
+### Requirement 7: Performance Optimization
+
+**User Story:** As a developer, I want the state management solution to be performant, so that state updates don't cause unnecessary re-renders.
+
+#### Acceptance Criteria
+
+1. WHEN state changes in one State_Slice, THE Store SHALL not trigger re-renders in components subscribed to other slices
+2. THE Selector functions SHALL use shallow equality checks to prevent unnecessary re-renders
+3. WHEN a component selects derived state, THE Selector SHALL memoize the computation
+4. THE Store SHALL support batching multiple state updates into a single render cycle
+
+### Requirement 8: Migration Path and Coexistence
+
+**User Story:** As a developer, I want the new state management to coexist with existing patterns, so that migration can be gradual and non-breaking.
+
+#### Acceptance Criteria
+
+1. THE State_Manager SHALL not require modifications to the existing WalletProvider
+2. THE Application SHALL continue to use WalletProvider for wallet-specific state
+3. THE Application SHALL use State_Manager only for Application_State
+4. THE Store initialization SHALL not block or delay WalletProvider initialization
+5. WHEN both providers are active, THE Application SHALL render without errors
+
+### Requirement 9: Type Safety and Developer Experience
+
+**User Story:** As a developer, I want full TypeScript support, so that I catch state-related errors at compile time.
+
+#### Acceptance Criteria
+
+1. THE Store SHALL export TypeScript types for all state shapes
+2. THE Actions SHALL have typed parameters enforced by TypeScript
+3. THE Selectors SHALL have typed return values enforced by TypeScript
+4. WHEN a developer uses an Action with incorrect parameters, THE TypeScript compiler SHALL report an error
+5. WHEN a developer accesses state with an incorrect path, THE TypeScript compiler SHALL report an error
+
+### Requirement 10: Testing Support
+
+**User Story:** As a developer, I want to test components that use global state, so that I can verify behavior in isolation.
+
+#### Acceptance Criteria
+
+1. THE Store SHALL provide a test utility for creating isolated store instances
+2. THE Store test utility SHALL accept initial state for test scenarios
+3. THE Store test utility SHALL work with React Testing Library
+4. WHEN testing a component with state dependencies, THE test SHALL be able to provide mock state
+5. THE Store SHALL allow Actions to be spied on or mocked in tests
+

--- a/Documents/Stellar-save/.kiro/specs/global-state-management/tasks.md
+++ b/Documents/Stellar-save/.kiro/specs/global-state-management/tasks.md
@@ -1,0 +1,244 @@
+# Implementation Plan: Global State Management
+
+## Overview
+
+This implementation plan breaks down the global state management feature into actionable tasks. The implementation uses Zustand with immer middleware for immutable updates and persistence middleware for localStorage/sessionStorage integration. The tasks follow an incremental approach: set up dependencies and structure, implement core slices, add persistence, create hooks and utilities, write tests, and finally integrate with the existing application.
+
+## Tasks
+
+- [ ] 1. Install dependencies and set up project structure
+  - Install zustand, immer, and @fast-check/vitest packages
+  - Create store directory structure (store/, store/slices/, store/middleware/, store/__tests__/)
+  - Create placeholder files for type definitions and test utilities
+  - _Requirements: 1.1, 1.2, 1.3_
+
+- [ ] 2. Define TypeScript types and interfaces
+  - [ ] 2.1 Create core type definitions in store/types.ts
+    - Define ViewMode, Theme, CurrencyDisplay types
+    - Define UIState and PreferencesState interfaces
+    - Define UIActions and PreferencesActions interfaces
+    - Define AppStoreState and AppStore combined types
+    - Define PersistenceConfig interface
+    - _Requirements: 2.4, 2.5, 9.1, 9.2, 9.3_
+  
+  - [ ] 2.2 Define default state constants
+    - Create DEFAULT_UI_STATE constant with initial values
+    - Create DEFAULT_PREFERENCES constant with initial values
+    - Export constants for use in store creation
+    - _Requirements: 2.1, 3.1_
+
+- [ ] 3. Implement UI state slice
+  - [ ] 3.1 Create uiSlice.ts with state and actions
+    - Implement toggleSidebar action
+    - Implement openModal and closeModal actions
+    - Implement setViewMode action
+    - Implement setTheme action
+    - Use immer for immutable updates
+    - _Requirements: 2.2, 2.5, 2.6, 3.2, 3.4_
+  
+  - [ ]* 3.2 Write unit tests for UI slice actions
+    - Test toggleSidebar toggles between true/false
+    - Test openModal sets activeModal correctly
+    - Test closeModal sets activeModal to null
+    - Test setViewMode updates viewMode
+    - Test setTheme updates theme
+    - _Requirements: 3.5_
+
+- [ ] 4. Implement user preferences slice
+  - [ ] 4.1 Create preferencesSlice.ts with state and actions
+    - Implement setLanguage action
+    - Implement setCurrencyDisplay action
+    - Implement toggleNotifications action
+    - Implement toggleSound action
+    - Implement resetPreferences action
+    - Use immer for immutable updates
+    - _Requirements: 2.3, 2.5, 2.6, 3.2, 3.4_
+  
+  - [ ]* 4.2 Write unit tests for preferences slice actions
+    - Test setLanguage updates language
+    - Test setCurrencyDisplay updates currency display
+    - Test toggleNotifications toggles notifications
+    - Test toggleSound toggles sound
+    - Test resetPreferences restores defaults
+    - _Requirements: 3.5_
+
+- [ ] 5. Implement persistence middleware
+  - [ ] 5.1 Create persistence configuration in store/middleware/persistence.ts
+    - Configure UI state persistence to sessionStorage
+    - Configure preferences persistence to localStorage
+    - Implement error handling for corrupted data
+    - Implement error handling for storage quota exceeded
+    - Implement error handling for unavailable storage
+    - Add version support for schema migrations
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6_
+  
+  - [ ]* 5.2 Write unit tests for persistence behavior
+    - Test preferences save to localStorage on update
+    - Test UI state saves to sessionStorage on update
+    - Test store hydrates from storage on initialization
+    - Test corrupted storage data falls back to defaults
+    - Test missing storage fields merge with defaults
+    - Test storage quota exceeded handled gracefully
+    - Test storage unavailable handled gracefully
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+- [ ] 6. Create combined Zustand store
+  - [ ] 6.1 Implement store creation in store/index.ts
+    - Combine UI slice and preferences slice
+    - Apply immer middleware for immutable updates
+    - Apply persistence middleware for both slices
+    - Configure Redux DevTools integration (development only)
+    - Export store instance and types
+    - _Requirements: 1.4, 2.1, 5.1, 5.2_
+  
+  - [ ]* 6.2 Write unit tests for store creation and initialization
+    - Test store initializes with correct default values
+    - Test store structure includes all required slices
+    - Test DevTools enabled in development environment
+    - Test DevTools disabled in production environment
+    - _Requirements: 2.1, 5.1, 5.2_
+
+- [ ] 7. Implement custom hooks for state access
+  - [ ] 7.1 Create custom hooks in store/index.ts
+    - Implement useUIState hook with optional selector
+    - Implement usePreferences hook with optional selector
+    - Implement useAppStore hook with optional selector
+    - Add TypeScript overloads for selector variants
+    - _Requirements: 6.4, 6.5, 7.2, 9.2, 9.3_
+  
+  - [ ]* 7.2 Write integration tests for React hooks
+    - Test components using useUIState re-render on UI state changes
+    - Test components using usePreferences re-render on preference changes
+    - Test components don't re-render on unrelated state changes
+    - Test multiple components can subscribe to same state
+    - Test hooks work with React Testing Library
+    - _Requirements: 6.5, 7.1, 7.2_
+
+- [ ] 8. Create testing utilities
+  - [ ] 8.1 Implement test utilities in store/testUtils.ts
+    - Create createTestStore function for isolated store instances
+    - Support custom initial state for test scenarios
+    - Ensure compatibility with React Testing Library
+    - Add utilities for spying on actions
+    - Add utilities for mocking state
+    - _Requirements: 10.1, 10.2, 10.3, 10.4, 10.5_
+  
+  - [ ]* 8.2 Write unit tests for testing utilities
+    - Test createTestStore creates isolated instances
+    - Test test store accepts custom initial state
+    - Test actions can be spied on in tests
+    - Test state can be mocked for component tests
+    - _Requirements: 10.1, 10.2, 10.4, 10.5_
+
+- [ ] 9. Checkpoint - Ensure all unit tests pass
+  - Run all unit tests and verify they pass
+  - Ensure all tests pass, ask the user if questions arise
+
+- [ ]* 10. Write property-based tests for correctness properties
+  - [ ]* 10.1 Write property test for immutable state updates
+    - **Property 1: Immutable State Updates**
+    - **Validates: Requirements 2.6, 3.4**
+    - Generate random initial states and actions
+    - Verify previous state object remains unchanged after action
+    - Use @fast-check/vitest with 100+ iterations
+  
+  - [ ]* 10.2 Write property test for preferences persistence
+    - **Property 2: Preferences Persistence to localStorage**
+    - **Validates: Requirements 4.1**
+    - Generate random preference values
+    - Verify localStorage contains updated values after action
+    - Use @fast-check/vitest with 100+ iterations
+  
+  - [ ]* 10.3 Write property test for UI state persistence
+    - **Property 3: UI State Persistence to sessionStorage**
+    - **Validates: Requirements 4.2**
+    - Generate random UI state values
+    - Verify sessionStorage contains updated values after action
+    - Use @fast-check/vitest with 100+ iterations
+  
+  - [ ]* 10.4 Write property test for serialization format
+    - **Property 4: Persistence Serialization Format**
+    - **Validates: Requirements 4.5**
+    - Generate random states
+    - Verify stored values are valid JSON that can be parsed
+    - Use @fast-check/vitest with 100+ iterations
+  
+  - [ ]* 10.5 Write property test for persistence round-trip
+    - **Property 5: Persistence Round-Trip**
+    - **Validates: Requirements 4.7**
+    - Generate random valid store states
+    - Verify persist→hydrate preserves all values
+    - Use @fast-check/vitest with 100+ iterations
+  
+  - [ ]* 10.6 Write property test for selective re-rendering
+    - **Property 6: Selective Re-rendering**
+    - **Validates: Requirements 6.5, 7.1**
+    - Generate random state changes in different slices
+    - Verify components only re-render when their selected state changes
+    - Use @fast-check/vitest with 100+ iterations
+  
+  - [ ]* 10.7 Write property test for selector memoization
+    - **Property 7: Selector Memoization**
+    - **Validates: Requirements 7.3**
+    - Generate random states and expensive selectors
+    - Verify selectors return memoized results without recomputing
+    - Use @fast-check/vitest with 100+ iterations
+  
+  - [ ]* 10.8 Write property test for batched state updates
+    - **Property 8: Batched State Updates**
+    - **Validates: Requirements 7.4**
+    - Generate random sequences of synchronous state updates
+    - Verify only one component re-render occurs per batch
+    - Use @fast-check/vitest with 100+ iterations
+
+- [ ] 11. Integrate store with existing application
+  - [ ] 11.1 Update main.tsx to initialize store
+    - Import store at application entry point
+    - Ensure store initialization doesn't block WalletProvider
+    - Verify no provider wrapping required for Zustand
+    - _Requirements: 6.1, 6.2, 6.3, 8.1, 8.4_
+  
+  - [ ] 11.2 Create example component using new state management
+    - Create a simple component that uses useUIState
+    - Create a simple component that uses usePreferences
+    - Demonstrate coexistence with useWallet hook
+    - Add to application to verify integration
+    - _Requirements: 6.4, 6.5, 8.2, 8.3, 8.5_
+  
+  - [ ]* 11.3 Write integration test for WalletProvider coexistence
+    - Test store works alongside WalletProvider without conflicts
+    - Test both useWallet and useUIState work in same component
+    - Test store initialization doesn't block WalletProvider initialization
+    - _Requirements: 1.5, 8.1, 8.2, 8.3, 8.4, 8.5_
+
+- [ ] 12. Configure DevTools for development
+  - [ ] 12.1 Set up Redux DevTools integration
+    - Configure DevTools to display current state values
+    - Configure DevTools to display state change history
+    - Configure DevTools to log action names and payloads
+    - Ensure DevTools only enabled in development environment
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+  
+  - [ ]* 12.2 Write unit tests for DevTools configuration
+    - Test DevTools enabled in development
+    - Test DevTools disabled in production
+    - Test DevTools connection failure doesn't break store
+    - _Requirements: 5.1, 5.2_
+
+- [ ] 13. Final checkpoint - Verify complete integration
+  - Run all tests (unit and property-based) and verify they pass
+  - Test the application manually to ensure state management works end-to-end
+  - Verify persistence works across browser sessions
+  - Verify DevTools integration in development mode
+  - Ensure all tests pass, ask the user if questions arise
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP delivery
+- Each task references specific requirements for traceability
+- Property-based tests validate universal correctness properties across all inputs
+- Unit tests validate specific examples, edge cases, and error conditions
+- The implementation uses TypeScript throughout for type safety
+- Zustand requires no provider wrapping, simplifying integration with existing WalletProvider
+- Persistence is handled via middleware, keeping slice code clean and focused
+- DevTools integration provides powerful debugging capabilities in development


### PR DESCRIPTION
Closes #82

---

- Add requirements document with 10 requirements
- Add design document using Zustand
- Add implementation tasks (13 tasks, 32 sub-tasks)
- Include 8 correctness properties for property-based testing

Related to issue #82 
<img width="1320" height="604" alt="paymesh1" src="https://github.com/user-attachments/assets/6ecaa77b-3df7-4147-98ac-e2a28bfedbd8" />
<img width="1188" height="494" alt="=paymesh 2" src="https://github.com/user-attachments/assets/5c7715d4-888d-4196-929c-2543c6f343d3" />
<img width="1295" height="663" alt="paaymesh3" src="https://github.com/user-attachments/assets/ff377574-4930-4c15-884e-8bc4cafa4cb1" />
<img width="1360" height="491" alt="paymesh4" src="https://github.com/user-attachments/assets/608fe446-25f6-402d-8ad3-3d632e417aba" />
