### PR TITLE
fix: validate that percentage is greater than 0 in add_group_member

### DIFF
--- a/contract/contracts/hello-world/src/autoshare_logic.rs
+++ b/contract/contracts/hello-world/src/autoshare_logic.rs
@@ -889,6 +889,9 @@ pub fn update_members(
     let mut seen_addresses = Vec::new(&env);
 
     for member in new_members.iter() {
+        if member.percentage == 0 {
+            return Err(Error::InvalidInput);
+        }
         total_percentage += member.percentage;
 
         for seen in seen_addresses.iter() {
@@ -1336,6 +1339,9 @@ fn validate_members(members: &Vec<GroupMember>) -> Result<(), Error> {
     let mut seen_addresses = Vec::new(env);
 
     for member in members.iter() {
+        if member.percentage == 0 {
+            return Err(Error::InvalidInput);
+        }
         total_percentage += member.percentage;
         for seen in seen_addresses.iter() {
             if seen == member.address {


### PR DESCRIPTION
This PR adds a check in add_group_member that validates that the percentage is greater than 0, which is a core requirement for a member to be added to a group.

Closes #71 