### PR TITLE
Implement reset_fundraising functionality

### DIFF
--- a/contract/contracts/hello-world/src/autoshare_logic.rs
+++ b/contract/contracts/hello-world/src/autoshare_logic.rs
@@ -1,8 +1,9 @@
 use crate::base::errors::Error;
 use crate::base::events::{
-    emit_contribution, emit_distribution, AdminTransferred, AutoshareCreated, AutoshareUpdated,
-    ContractPaused, ContractUnpaused, FundraisingStarted, GroupActivated, GroupDeactivated,
-    GroupDeleted, GroupNameUpdated, Withdrawal,
+    emit_contribution, emit_distribution, emit_fundraising_reset, AdminTransferred,
+    AutoshareCreated, AutoshareUpdated, ContractPaused, ContractUnpaused,
+    FundraisingStarted, GroupActivated, GroupDeactivated, GroupDeleted,
+    GroupNameUpdated, Withdrawal,
 };
 
 use crate::base::types::{
@@ -983,8 +984,6 @@ pub fn get_total_usages_paid(env: Env, id: BytesN<32>) -> Result<u32, Error> {
     Ok(details.total_usages_paid)
 }
 
-#[cfg(test)]
-#[allow(dead_code)]
 pub fn reduce_usage(env: Env, id: BytesN<32>) -> Result<(), Error> {
     let key = DataKey::AutoShare(id);
     let mut details: AutoShareDetails = env
@@ -1917,6 +1916,61 @@ pub fn get_fundraising_remaining(env: Env, id: BytesN<32>) -> i128 {
     } else {
         0
     }
+}
+
+pub fn reset_fundraising(env: Env, id: BytesN<32>, caller: Address) -> Result<(), Error> {
+    // 1. Authorize caller
+    caller.require_auth();
+
+    // 2. Check if contract is paused
+    if get_paused_status(&env) {
+        return Err(Error::ContractPaused);
+    }
+
+    // 3. Verify group existence and creator
+    let key = DataKey::AutoShare(id.clone());
+    let details: AutoShareDetails = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(Error::NotFound)?;
+    bump_persistent(&env, &key);
+
+    if details.creator != caller {
+        return Err(Error::Unauthorized);
+    }
+
+    // 4. Check fundraising exists and is NOT active
+    let fundraising_key = DataKey::GroupFundraising(id.clone());
+    let config: FundraisingConfig = env
+        .storage()
+        .persistent()
+        .get(&fundraising_key)
+        .ok_or(Error::FundraisingNotActive)?;
+    bump_persistent(&env, &fundraising_key);
+
+    if config.is_active {
+        return Err(Error::FundraisingAlreadyActive);
+    }
+
+    // 5. Remove current fundraising configuration
+    env.storage().persistent().remove(&fundraising_key);
+
+    // 6. Clear contributions and stats for a fresh start
+    let contributions_key = DataKey::GroupContributions(id.clone());
+    if env.storage().persistent().has(&contributions_key) {
+        env.storage().persistent().remove(&contributions_key);
+    }
+
+    let stats_key = DataKey::GroupStats(id.clone());
+    if env.storage().persistent().has(&stats_key) {
+        env.storage().persistent().remove(&stats_key);
+    }
+
+    // 7. Emit reset event
+    emit_fundraising_reset(&env, id);
+
+    Ok(())
 }
 
 pub fn get_groups_by_member_paginated(

--- a/contract/contracts/hello-world/src/base/events.rs
+++ b/contract/contracts/hello-world/src/base/events.rs
@@ -212,3 +212,14 @@ pub fn emit_fundraising_completed(
     }
     .publish(env);
 }
+
+#[contractevent(data_format = "single-value")]
+#[derive(Clone)]
+pub struct FundraisingReset {
+    #[topic]
+    pub id: BytesN<32>,
+}
+
+pub fn emit_fundraising_reset(env: &Env, id: BytesN<32>) {
+    FundraisingReset { id }.publish(env);
+}

--- a/contract/contracts/hello-world/src/lib.rs
+++ b/contract/contracts/hello-world/src/lib.rs
@@ -388,6 +388,11 @@ impl AutoShareContract {
     pub fn get_fundraising_remaining(env: Env, id: BytesN<32>) -> i128 {
         autoshare_logic::get_fundraising_remaining(env, id)
     }
+
+    /// Resets a completed or cancelled fundraising campaign.
+    pub fn reset_fundraising(env: Env, id: BytesN<32>, caller: Address) {
+        autoshare_logic::reset_fundraising(env, id, caller).unwrap();
+    }
 }
 
 // 3. Link the tests (Requirement: Unit Tests)
@@ -474,3 +479,7 @@ mod event_emission_test;
 #[cfg(test)]
 #[path = "tests/delete_group_test.rs"]
 mod delete_group_test;
+
+#[cfg(test)]
+#[path = "tests/fundraising_reset_test.rs"]
+mod fundraising_reset_test;

--- a/contract/contracts/hello-world/src/tests/fundraising_reset_test.rs
+++ b/contract/contracts/hello-world/src/tests/fundraising_reset_test.rs
@@ -1,0 +1,111 @@
+#![cfg(test)]
+
+use crate::test_utils::{setup_test_env, mint_tokens};
+use crate::AutoShareContractClient;
+use soroban_sdk::{BytesN, String};
+
+#[test]
+fn test_reset_fundraising_success() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+
+    let creator = test_env.users.get(0).unwrap();
+    let token = test_env.mock_tokens.get(0).unwrap();
+    
+    // Fund creator
+    mint_tokens(env, &token, &creator, 1000000);
+    
+    // Create group
+    let group_id = BytesN::from_array(env, &[1u8; 32]);
+    let name = String::from_str(env, "Test Group");
+    client.create(&group_id, &name, &creator, &100, &token);
+    
+    // Add member (required for distribution during contribution)
+    let member = test_env.users.get(2).unwrap();
+    client.add_group_member(&group_id, &creator, &member, &100);
+
+    // Start fundraising
+    client.start_fundraising(&group_id, &creator, &1000);
+    
+    // Fund and contribute
+    let contributor = test_env.users.get(1).unwrap();
+    mint_tokens(env, &token, &contributor, 1000);
+    client.contribute(&group_id, &token, &1000, &contributor);
+    
+    // Verify it's inactive (completed)
+    let status = client.get_fundraising_status(&group_id);
+    assert!(!status.is_active);
+    assert_eq!(status.total_raised, 1000);
+    
+    // Reset fundraising
+    client.reset_fundraising(&group_id, &creator);
+    
+    // Verify it's cleared
+    let status_after = client.get_fundraising_status(&group_id);
+    assert_eq!(status_after.target_amount, 0);
+    assert_eq!(status_after.total_raised, 0);
+    
+    // Verify contributions are cleared
+    let contributions = client.get_group_contributions(&group_id);
+    assert_eq!(contributions.len(), 0);
+    
+    // Can start a new one
+    client.start_fundraising(&group_id, &creator, &2000);
+    let status_new = client.get_fundraising_status(&group_id);
+    assert!(status_new.is_active);
+    assert_eq!(status_new.target_amount, 2000);
+}
+
+#[test]
+#[should_panic(expected = "FundraisingAlreadyActive")]
+fn test_reset_fundraising_active_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+
+    let creator = test_env.users.get(0).unwrap();
+    let token = test_env.mock_tokens.get(0).unwrap();
+    
+    mint_tokens(env, &token, &creator, 1000000);
+    
+    let group_id = BytesN::from_array(env, &[2u8; 32]);
+    let name = String::from_str(env, "Test Group");
+    client.create(&group_id, &name, &creator, &100, &token);
+    
+    // Add member
+    let member = test_env.users.get(2).unwrap();
+    client.add_group_member(&group_id, &creator, &member, &100);
+
+    client.start_fundraising(&group_id, &creator, &1000);
+    
+    // Try to reset active campaign - should fail
+    client.reset_fundraising(&group_id, &creator);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_reset_fundraising_non_creator_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+
+    let creator = test_env.users.get(0).unwrap();
+    let non_creator = test_env.users.get(1).unwrap();
+    let token = test_env.mock_tokens.get(0).unwrap();
+    
+    mint_tokens(env, &token, &creator, 1000000);
+    
+    let group_id = BytesN::from_array(env, &[3u8; 32]);
+    let name = String::from_str(env, "Test Group");
+    client.create(&group_id, &name, &creator, &100, &token);
+    
+    // Add member
+    let member = test_env.users.get(2).unwrap();
+    client.add_group_member(&group_id, &creator, &member, &100);
+
+    client.start_fundraising(&group_id, &creator, &1000);
+    
+    // Try to reset by non-creator - should fail
+    client.reset_fundraising(&group_id, &non_creator);
+}


### PR DESCRIPTION
## Changes
- Added [FundraisingReset] event to enable tracking of campaign resets.
- Implemented [reset_fundraising] write function in [autoshare_logic.rs]
    - Ensures only the group creator can reset the campaign.
    - Validates that an active campaign cannot be reset.
    - Clears all fundraising-related data (`GroupFundraising`, `GroupContributions`, [GroupStats]) to allow starting a fresh campaign.
    - Emits [FundraisingReset]) event.
- Fixed a compilation issue where [reduce_usage] was incorrectly restricted to test builds only via `#[cfg(test)]`.
- Exposed [reset_fundraising] in the [AutoShareContract] interface.
- Added comprehensive unit tests in [fundraising_reset_test.rs] covering success and failure paths.

## Verification Results
- Ran `cargo test fundraising_reset_test`: All 3 tests passed.
- Total 182 tests in the suite are passing.

## Related Issues
Closes #174 
