### PR TITLE
fix: add-get_member_percentage-read-function-to-get-a-specific-member…

### DIFF
--- a/contract/contracts/hello-world/src/autoshare_logic.rs
+++ b/contract/contracts/hello-world/src/autoshare_logic.rs
@@ -339,6 +339,16 @@ pub fn get_group_members(env: Env, id: BytesN<32>) -> Result<Vec<GroupMember>, E
     Ok(details.members)
 }
 
+pub fn get_member_percentage(env: Env, id: BytesN<32>, member: Address) -> Result<u32, Error> {
+    let details = get_autoshare(env, id)?;
+    for m in details.members.iter() {
+        if m.address == member {
+            return Ok(m.percentage);
+        }
+    }
+    Err(Error::MemberNotFound)
+}
+
 pub fn add_group_member(
     env: Env,
     id: BytesN<32>,

--- a/contract/contracts/hello-world/src/interfaces/autoshare.rs
+++ b/contract/contracts/hello-world/src/interfaces/autoshare.rs
@@ -85,6 +85,9 @@ pub trait AutoShareTrait {
     /// Returns all members of a group.
     fn get_group_members(env: Env, id: BytesN<32>) -> Vec<GroupMember>;
 
+    /// Returns a specific member's share (percentage) in a group.
+    fn get_member_percentage(env: Env, id: BytesN<32>, member: Address) -> u32;
+
     /// Adds a member to a group with specified percentage.
     /// Only the group creator (caller) may add members.
     fn add_group_member(

--- a/contract/contracts/hello-world/src/lib.rs
+++ b/contract/contracts/hello-world/src/lib.rs
@@ -161,6 +161,10 @@ impl AutoShareContract {
         autoshare_logic::get_group_members(env, id).unwrap()
     }
 
+    pub fn get_member_percentage(env: Env, id: BytesN<32>, member: Address) -> u32 {
+        autoshare_logic::get_member_percentage(env, id, member).unwrap()
+    }
+
     /// Adds a member to a group with specified percentage.
     /// Only the group creator (caller) may add members.
     pub fn add_group_member(

--- a/contract/contracts/hello-world/src/tests/autoshare_test.rs
+++ b/contract/contracts/hello-world/src/tests/autoshare_test.rs
@@ -592,6 +592,78 @@ fn test_get_group_members_non_existent_group() {
     client.get_group_members(&id);
 }
 
+#[test]
+fn test_get_member_percentage_success() {
+    let test_env = setup_test_env();
+    let client = AutoShareContractClient::new(&test_env.env, &test_env.autoshare_contract);
+
+    let creator = test_env.users.get(0).unwrap().clone();
+    let member1 = Address::generate(&test_env.env);
+    let member2 = Address::generate(&test_env.env);
+
+    let mut members = Vec::new(&test_env.env);
+    members.push_back(GroupMember {
+        address: member1.clone(),
+        percentage: 60,
+    });
+    members.push_back(GroupMember {
+        address: member2.clone(),
+        percentage: 40,
+    });
+
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let id = create_test_group(
+        &test_env.env,
+        &test_env.autoshare_contract,
+        &creator,
+        &members,
+        1,
+        &token,
+    );
+
+    assert_eq!(client.get_member_percentage(&id, &member1), 60);
+    assert_eq!(client.get_member_percentage(&id, &member2), 40);
+}
+
+#[test]
+#[should_panic] // MemberNotFound
+fn test_get_member_percentage_member_not_found() {
+    let test_env = setup_test_env();
+    let client = AutoShareContractClient::new(&test_env.env, &test_env.autoshare_contract);
+
+    let creator = test_env.users.get(0).unwrap().clone();
+    let member = Address::generate(&test_env.env);
+    let mut members = Vec::new(&test_env.env);
+    members.push_back(GroupMember {
+        address: member.clone(),
+        percentage: 100,
+    });
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+
+    let id = create_test_group(
+        &test_env.env,
+        &test_env.autoshare_contract,
+        &creator,
+        &members,
+        1,
+        &token,
+    );
+
+    let non_member = Address::generate(&test_env.env);
+    client.get_member_percentage(&id, &non_member);
+}
+
+#[test]
+#[should_panic] // NotFound (Group not found)
+fn test_get_member_percentage_group_not_found() {
+    let test_env = setup_test_env();
+    let client = AutoShareContractClient::new(&test_env.env, &test_env.autoshare_contract);
+
+    let id = BytesN::from_array(&test_env.env, &[99u8; 32]);
+    let member = Address::generate(&test_env.env);
+    client.get_member_percentage(&id, &member);
+}
+
 // ============================================
 // Add Group Member Tests
 // ============================================


### PR DESCRIPTION
…s-share-in-a-group(closes #148)

I have implemented the `get_member_percentage` read function and added comprehensive unit tests to verify its behavior.

Summary of Work:

Interface Update: Added `get_member_percentage` to the `AutoShareTrait` in `src/interfaces/autoshare.rs`.

Logic Implementation: Implemented the function in `src/autoshare_logic.rs`. It retrieves group details, searches for the specified member, and returns their percentage share. It includes error handling for non-existent groups (`Error::NotFound`) and non-member addresses (`Error::MemberNotFound`).

Contract Exposure: Added the function to the `AutoShareContract` in `src/lib.rs`.
Test Coverage: Added three new tests in `src/tests/autoshare_test.rs` covering success and failure scenarios