### PR TITLE
Payment group tests and create/remove entrypoints

### DIFF
--- a/contract/contracts/hello-world/src/lib.rs
+++ b/contract/contracts/hello-world/src/lib.rs
@@ -75,6 +75,22 @@ impl AutoShareContract {
             .unwrap();
     }
 
+    /// Creates a payment group (AutoShare plan). Semantically identical to [`Self::create`].
+    ///
+    /// This entrypoint exists for integrators and documentation that refer to
+    /// “payment group” lifecycle naming.
+    pub fn create_payment_group(
+        env: Env,
+        id: BytesN<32>,
+        name: String,
+        creator: Address,
+        usage_count: u32,
+        payment_token: Address,
+    ) {
+        autoshare_logic::create_autoshare(env, id, name, creator, usage_count, payment_token)
+            .unwrap();
+    }
+
     /// Update members of an existing AutoShare plan.
     /// Requirement: Only creator can update. Validates percentages.
     pub fn update_members(
@@ -264,6 +280,16 @@ impl AutoShareContract {
     /// Removes a single member from a group. Only the creator can call; group must be active.
     /// After removal, remaining percentages may not sum to 100; call update_members to set a valid split.
     pub fn remove_group_member(env: Env, id: BytesN<32>, caller: Address, member_address: Address) {
+        autoshare_logic::remove_group_member(env, id, caller, member_address).unwrap();
+    }
+
+    /// Removes a member from a payment group. Semantically identical to [`Self::remove_group_member`].
+    pub fn remove_member_from_group(
+        env: Env,
+        id: BytesN<32>,
+        caller: Address,
+        member_address: Address,
+    ) {
         autoshare_logic::remove_group_member(env, id, caller, member_address).unwrap();
     }
 
@@ -774,6 +800,18 @@ mod usage_tracking_test;
 #[cfg(test)]
 #[path = "tests/group_creation_boundary_test.rs"]
 mod group_creation_boundary_test;
+
+#[cfg(test)]
+#[path = "tests/create_payment_group_test.rs"]
+mod create_payment_group_test;
+
+#[cfg(test)]
+#[path = "tests/create_payment_group_boundary_test.rs"]
+mod create_payment_group_boundary_test;
+
+#[cfg(test)]
+#[path = "tests/remove_member_from_group_test.rs"]
+mod remove_member_from_group_test;
 
 #[cfg(test)]
 #[path = "tests/group_lifecycle_test.rs"]

--- a/contract/contracts/hello-world/src/tests/create_payment_group_boundary_test.rs
+++ b/contract/contracts/hello-world/src/tests/create_payment_group_boundary_test.rs
@@ -1,0 +1,70 @@
+//! Boundary and edge-case tests for payment group creation (`create_payment_group`).
+
+use crate::test_utils::{fund_user_with_tokens, setup_test_env};
+use crate::AutoShareContractClient;
+use soroban_sdk::{BytesN, String};
+
+#[test]
+fn test_create_payment_group_large_usage_count_succeeds() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let id = BytesN::from_array(env, &[210u8; 32]);
+    let usage = 500u32;
+    let fee: i128 = client.get_usage_fee() as i128;
+    let needed = usage as i128 * fee + 10_000;
+
+    fund_user_with_tokens(env, &token, &creator, needed);
+
+    client.create_payment_group(
+        &id,
+        &String::from_str(env, "High volume group"),
+        &creator,
+        &usage,
+        &token,
+    );
+
+    let g = client.get(&id);
+    assert_eq!(g.usage_count, usage);
+}
+
+#[test]
+#[should_panic(expected = "EmptyName")]
+fn test_create_payment_group_whitespace_only_name_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let id = BytesN::from_array(env, &[211u8; 32]);
+
+    fund_user_with_tokens(env, &token, &creator, 5_000);
+    client.create_payment_group(
+        &id,
+        &String::from_str(env, "   \t\n"),
+        &creator,
+        &1,
+        &token,
+    );
+}
+
+#[test]
+#[should_panic(expected = "EmptyName")]
+fn test_create_payment_group_name_over_max_length_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let id = BytesN::from_array(env, &[212u8; 32]);
+
+    fund_user_with_tokens(env, &token, &creator, 5_000);
+    let long = String::from_str(
+        env,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    assert_eq!(long.len(), 61);
+    client.create_payment_group(&id, &long, &creator, &1, &token);
+}

--- a/contract/contracts/hello-world/src/tests/create_payment_group_test.rs
+++ b/contract/contracts/hello-world/src/tests/create_payment_group_test.rs
@@ -1,0 +1,168 @@
+//! Unit tests for `create_payment_group` (payment group creation).
+
+use crate::base::types::GroupMember;
+use crate::test_utils::{deploy_mock_token, fund_user_with_tokens, setup_test_env};
+use crate::AutoShareContractClient;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, String, Vec};
+
+#[test]
+fn test_create_payment_group_success_stores_creator_usage_and_token_config() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let id = BytesN::from_array(env, &[201u8; 32]);
+    let usage = 7u32;
+
+    fund_user_with_tokens(env, &token, &creator, 50_000);
+
+    client.create_payment_group(
+        &id,
+        &String::from_str(env, "Team payouts"),
+        &creator,
+        &usage,
+        &token,
+    );
+
+    let group = client.get(&id);
+    assert_eq!(group.creator, creator);
+    assert_eq!(group.usage_count, usage);
+    assert_eq!(group.total_usages_paid, usage);
+    assert!(group.is_active);
+    assert_eq!(group.members.len(), 0);
+}
+
+#[test]
+fn test_create_payment_group_then_update_members_sets_initial_split() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let id = BytesN::from_array(env, &[202u8; 32]);
+
+    fund_user_with_tokens(env, &token, &creator, 20_000);
+    client.create_payment_group(
+        &id,
+        &String::from_str(env, "Ops split"),
+        &creator,
+        &3,
+        &token,
+    );
+
+    let m1 = Address::generate(env);
+    let m2 = Address::generate(env);
+    let mut members = Vec::new(env);
+    members.push_back(GroupMember {
+        address: m1.clone(),
+        percentage: 60,
+    });
+    members.push_back(GroupMember {
+        address: m2.clone(),
+        percentage: 40,
+    });
+    client.update_members(&id, &creator, &members);
+
+    let stored = client.get_group_members(&id);
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored.get(0).unwrap().percentage, 60);
+    assert_eq!(stored.get(1).unwrap().percentage, 40);
+}
+
+#[test]
+#[should_panic(expected = "AlreadyExists")]
+fn test_create_payment_group_duplicate_id_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let id = BytesN::from_array(env, &[203u8; 32]);
+
+    fund_user_with_tokens(env, &token, &creator, 30_000);
+    client.create_payment_group(
+        &id,
+        &String::from_str(env, "First"),
+        &creator,
+        &2,
+        &token,
+    );
+    client.create_payment_group(
+        &id,
+        &String::from_str(env, "Second"),
+        &creator,
+        &2,
+        &token,
+    );
+}
+
+#[test]
+#[should_panic(expected = "InvalidUsageCount")]
+fn test_create_payment_group_zero_usage_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let id = BytesN::from_array(env, &[204u8; 32]);
+
+    fund_user_with_tokens(env, &token, &creator, 10_000);
+    client.create_payment_group(
+        &id,
+        &String::from_str(env, "Bad usage"),
+        &creator,
+        &0,
+        &token,
+    );
+}
+
+#[test]
+#[should_panic(expected = "UnsupportedToken")]
+fn test_create_payment_group_unsupported_token_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let supported = test_env.mock_tokens.get(0).unwrap().clone();
+    let unsupported = deploy_mock_token(
+        env,
+        &String::from_str(env, "Other"),
+        &String::from_str(env, "OTH"),
+    );
+
+    fund_user_with_tokens(env, &supported, &creator, 10_000);
+    fund_user_with_tokens(env, &unsupported, &creator, 10_000);
+
+    let id = BytesN::from_array(env, &[205u8; 32]);
+    client.create_payment_group(
+        &id,
+        &String::from_str(env, "Rogue token"),
+        &creator,
+        &1,
+        &unsupported,
+    );
+}
+
+#[test]
+#[should_panic(expected = "ContractPaused")]
+fn test_create_payment_group_when_paused_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let admin = client.get_admin();
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+    let id = BytesN::from_array(env, &[206u8; 32]);
+
+    fund_user_with_tokens(env, &token, &creator, 10_000);
+    client.pause(&admin);
+
+    client.create_payment_group(
+        &id,
+        &String::from_str(env, "While paused"),
+        &creator,
+        &1,
+        &token,
+    );
+}

--- a/contract/contracts/hello-world/src/tests/remove_member_from_group_test.rs
+++ b/contract/contracts/hello-world/src/tests/remove_member_from_group_test.rs
@@ -1,0 +1,197 @@
+//! Unit tests for `remove_member_from_group` (member removal from a payment group).
+
+use crate::base::types::GroupMember;
+use crate::test_utils::{create_test_group, fund_user_with_tokens, mint_tokens, setup_test_env};
+use crate::AutoShareContractClient;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, String, Vec};
+
+#[test]
+fn test_remove_member_from_group_success_updates_member_list() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+
+    let m1 = Address::generate(env);
+    let m2 = Address::generate(env);
+    let mut members = Vec::new(env);
+    members.push_back(GroupMember {
+        address: m1.clone(),
+        percentage: 55,
+    });
+    members.push_back(GroupMember {
+        address: m2.clone(),
+        percentage: 45,
+    });
+
+    let id = create_test_group(env, &test_env.autoshare_contract, &creator, &members, 2, &token);
+    assert_eq!(client.get_group_members(&id).len(), 2);
+
+    client.remove_member_from_group(&id, &creator, &m2);
+
+    let after = client.get_group_members(&id);
+    assert_eq!(after.len(), 1);
+    assert_eq!(after.get(0).unwrap().address, m1);
+    assert!(!client.is_group_member(&id, &m2));
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_remove_member_from_group_non_creator_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+
+    let m1 = Address::generate(env);
+    let m2 = Address::generate(env);
+    let mut members = Vec::new(env);
+    members.push_back(GroupMember {
+        address: m1.clone(),
+        percentage: 50,
+    });
+    members.push_back(GroupMember {
+        address: m2.clone(),
+        percentage: 50,
+    });
+
+    let id = create_test_group(env, &test_env.autoshare_contract, &creator, &members, 1, &token);
+    let attacker = Address::generate(env);
+    client.remove_member_from_group(&id, &attacker, &m2);
+}
+
+#[test]
+#[should_panic(expected = "MemberNotFound")]
+fn test_remove_member_from_group_unknown_member_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+
+    let m1 = Address::generate(env);
+    let mut members = Vec::new(env);
+    members.push_back(GroupMember {
+        address: m1.clone(),
+        percentage: 100,
+    });
+
+    let id = create_test_group(env, &test_env.autoshare_contract, &creator, &members, 1, &token);
+    let ghost = Address::generate(env);
+    client.remove_member_from_group(&id, &creator, &ghost);
+}
+
+#[test]
+#[should_panic(expected = "GroupInactive")]
+fn test_remove_member_from_group_inactive_group_fails() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+
+    let m1 = Address::generate(env);
+    let m2 = Address::generate(env);
+    let mut members = Vec::new(env);
+    members.push_back(GroupMember {
+        address: m1.clone(),
+        percentage: 50,
+    });
+    members.push_back(GroupMember {
+        address: m2.clone(),
+        percentage: 50,
+    });
+
+    let id = create_test_group(env, &test_env.autoshare_contract, &creator, &members, 1, &token);
+    client.deactivate_group(&id, &creator);
+    client.remove_member_from_group(&id, &creator, &m2);
+}
+
+#[test]
+fn test_remove_member_from_group_after_distribution_succeeds() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator = test_env.users.get(0).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+
+    let m1 = Address::generate(env);
+    let m2 = Address::generate(env);
+    let mut members = Vec::new(env);
+    members.push_back(GroupMember {
+        address: m1.clone(),
+        percentage: 50,
+    });
+    members.push_back(GroupMember {
+        address: m2.clone(),
+        percentage: 50,
+    });
+
+    let usages = 3u32;
+    let id = create_test_group(env, &test_env.autoshare_contract, &creator, &members, usages, &token);
+
+    let sender = test_env.users.get(1).unwrap().clone();
+    mint_tokens(env, &token, &sender, 2_000);
+    client.distribute(&id, &token, &1_000, &sender);
+
+    assert_eq!(client.get_group_distributions(&id).len(), 1);
+
+    client.remove_member_from_group(&id, &creator, &m2);
+
+    let remaining = client.get_group_members(&id);
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining.get(0).unwrap().address, m1);
+    assert_eq!(client.get_remaining_usages(&id), usages - 1);
+}
+
+#[test]
+fn test_remove_member_from_group_updates_member_groups_index() {
+    let test_env = setup_test_env();
+    let env = &test_env.env;
+    let client = AutoShareContractClient::new(env, &test_env.autoshare_contract);
+    let creator_a = test_env.users.get(0).unwrap().clone();
+    let creator_b = test_env.users.get(1).unwrap().clone();
+    let token = test_env.mock_tokens.get(0).unwrap().clone();
+
+    let shared = Address::generate(env);
+
+    let mut members_a = Vec::new(env);
+    members_a.push_back(GroupMember {
+        address: shared.clone(),
+        percentage: 100,
+    });
+    let id_a = create_test_group(
+        env,
+        &test_env.autoshare_contract,
+        &creator_a,
+        &members_a,
+        1,
+        &token,
+    );
+
+    let mut members_b = Vec::new(env);
+    members_b.push_back(GroupMember {
+        address: shared.clone(),
+        percentage: 100,
+    });
+    let id_b = BytesN::from_array(env, &[220u8; 32]);
+    fund_user_with_tokens(env, &token, &creator_b, 10_000);
+    client.create_payment_group(
+        &id_b,
+        &String::from_str(env, "Group B"),
+        &creator_b,
+        &1,
+        &token,
+    );
+    client.update_members(&id_b, &creator_b, &members_b);
+
+    assert_eq!(client.get_groups_by_member(&shared).len(), 2);
+
+    client.remove_member_from_group(&id_b, &creator_b, &shared);
+
+    let groups_for_shared = client.get_groups_by_member(&shared);
+    assert_eq!(groups_for_shared.len(), 1);
+    assert_eq!(groups_for_shared.get(0).unwrap().id, id_a);
+}


### PR DESCRIPTION
## Summary
- Adds **`create_payment_group`** and **`remove_member_from_group`** as documented aliases of `create` / `remove_group_member` (#242).
- Adds **`create_payment_group_test`**: success paths, duplicate id, zero usage, unsupported token, paused contract (#238).
- Adds **`create_payment_group_boundary_test`**: large usage count, whitespace-only name, name over max length (#239).
- Adds **`remove_member_from_group_test`**: success, unauthorized, unknown member, inactive group, removal after distribution, `MemberGroups` index update (#263).

## Test plan
- `cd contract/contracts/hello-world && cargo test`

Closes #238
Closes #239
Closes #242
Closes #263

Made with [Cursor](https://cursor.com)