### PR TITLE
Feature/update payment group advanced tests

### DIFF
--- a/contract/contracts/hello-world/src/autoshare_logic.rs
+++ b/contract/contracts/hello-world/src/autoshare_logic.rs
@@ -35,6 +35,8 @@ pub enum DataKey {
     GroupDistributions(BytesN<32>),
     MaxMembers,
     MinContribution,
+    ProtocolFee,
+    GroupProtocolFee(BytesN<32>),
 }
 
 const DAY_IN_LEDGERS: u32 = 17280;
@@ -686,7 +688,7 @@ pub fn add_group_member(
 
     AutoshareUpdated {
         id: id.clone(),
-        updater: caller,
+        updater: caller.clone(),
         name_updated: false,
         metadata_updated: false,
         new_creator: None,
@@ -1137,6 +1139,55 @@ pub fn get_usage_fee(env: Env) -> u32 {
         bump_persistent(&env, &fee_key);
     }
     result.unwrap_or(10u32)
+}
+
+/// Sets the global protocol fee percentage (0–100). Pass `group_id = None` for the global
+/// default, or `Some(id)` to override the fee for a specific group. Admin only.
+pub fn set_protocol_fee(
+    env: Env,
+    admin: Address,
+    fee_percent: u32,
+    group_id: Option<BytesN<32>>,
+) -> Result<(), Error> {
+    admin.require_auth();
+    require_admin(&env, &admin)?;
+
+    if fee_percent > 100 {
+        return Err(Error::InvalidInput);
+    }
+
+    match group_id {
+        Some(id) => {
+            let key = DataKey::GroupProtocolFee(id);
+            env.storage().persistent().set(&key, &fee_percent);
+            bump_persistent(&env, &key);
+        }
+        None => {
+            let key = DataKey::ProtocolFee;
+            env.storage().persistent().set(&key, &fee_percent);
+            bump_persistent(&env, &key);
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns the effective protocol fee percentage for a group.
+/// Falls back to the global protocol fee if no group-specific override is set.
+pub fn get_protocol_fee(env: Env, group_id: Option<BytesN<32>>) -> u32 {
+    if let Some(id) = group_id {
+        let group_key = DataKey::GroupProtocolFee(id);
+        if let Some(fee) = env.storage().persistent().get::<DataKey, u32>(&group_key) {
+            bump_persistent(&env, &group_key);
+            return fee;
+        }
+    }
+    let global_key = DataKey::ProtocolFee;
+    let result: Option<u32> = env.storage().persistent().get(&global_key);
+    if result.is_some() {
+        bump_persistent(&env, &global_key);
+    }
+    result.unwrap_or(0u32)
 }
 
 pub fn set_max_members(env: Env, admin: Address, max: u32) -> Result<(), Error> {

--- a/contract/contracts/hello-world/src/autoshare_logic.rs
+++ b/contract/contracts/hello-world/src/autoshare_logic.rs
@@ -1,14 +1,15 @@
 use crate::base::errors::Error;
 use crate::base::events::{
     emit_contribution, emit_creator_is_member, emit_distribution, emit_fundraising_cancelled,
-    emit_fundraising_target_updated, emit_max_members_updated, emit_member_removed,
-    emit_payment_group_deactivated, emit_usage_fee_updated, AdminTransferred, AutoshareCreated,
-    AutoshareUpdated, ContractPaused, ContractUnpaused, FundraisingStarted, GroupActivated,
-    GroupDeactivated, GroupDeleted, GroupNameUpdated, GroupOwnershipTransferred, Withdrawal,
+    emit_fundraising_target_updated, emit_funds_deposited, emit_max_members_updated,
+    emit_member_removed, emit_payment_group_deactivated, emit_usage_fee_updated, AdminTransferred,
+    AutoshareCreated, AutoshareUpdated, ContractPaused, ContractUnpaused, FundraisingStarted,
+    GroupActivated, GroupDeactivated, GroupDeleted, GroupNameUpdated, GroupOwnershipTransferred,
+    Withdrawal,
 };
 
 use crate::base::types::{
-    ActiveFundraising, AutoShareDetails, DistributionHistory, DistributionRecord,
+    ActiveFundraising, AutoShareDetails, DepositRecord, DistributionHistory, DistributionRecord,
     FundraisingConfig, FundraisingContribution, GroupMember, GroupPage, GroupStats, GroupSummary,
     MemberAmount, MemberDistributionRecord, PaymentHistory,
 };
@@ -37,6 +38,12 @@ pub enum DataKey {
     MinContribution,
     ProtocolFee,
     GroupProtocolFee(BytesN<32>),
+    // Treasury: per-group, per-token accumulated balance available for distribution
+    GroupTreasury(BytesN<32>, Address),
+    // Deposit history: per-group ordered list of DepositRecord
+    GroupDepositHistory(BytesN<32>),
+    // Depositor history: per-address ordered list of DepositRecord
+    DepositorHistory(Address),
 }
 
 const DAY_IN_LEDGERS: u32 = 17280;
@@ -3309,4 +3316,153 @@ pub fn cancel_fundraising(env: Env, id: BytesN<32>, caller: Address) -> Result<(
     emit_fundraising_cancelled(&env, id.clone(), total_raised_at_cancellation);
 
     Ok(())
+}
+
+// ============================================================================
+// Treasury — deposit_funds
+// ============================================================================
+
+/// Deposits `amount` of `token` into the group's treasury, making those funds
+/// available for future `distribute` calls without requiring the sender to be
+/// present at distribution time.
+///
+/// # Checks (in order)
+/// 1. `depositor` must authorize the call.
+/// 2. Contract must not be paused.
+/// 3. `amount` must be > 0.
+/// 4. `token` must be on the supported-token list.
+/// 5. Group identified by `id` must exist.
+/// 6. Group must be active.
+///
+/// # Storage mutations
+/// - Transfers `amount` of `token` from `depositor` to the contract address.
+/// - Increments `GroupTreasury(id, token)` by `amount`.
+/// - Appends a `DepositRecord` to `GroupDepositHistory(id)`.
+/// - Appends a `DepositRecord` to `DepositorHistory(depositor)`.
+///
+/// # Events
+/// Emits `FundsDeposited { group_id, depositor, token, amount, new_treasury_balance }`.
+pub fn deposit_funds(
+    env: Env,
+    id: BytesN<32>,
+    token: Address,
+    amount: i128,
+    depositor: Address,
+) -> Result<(), Error> {
+    // 1. Authorization
+    depositor.require_auth();
+
+    // 2. Pause guard
+    if get_paused_status(&env) {
+        return Err(Error::ContractPaused);
+    }
+
+    // 3. Amount validation — must be strictly positive
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    // 4. Token must be supported
+    if !is_token_supported(env.clone(), token.clone()) {
+        return Err(Error::UnsupportedToken);
+    }
+
+    // 5 & 6. Group must exist and be active
+    let group_key = DataKey::AutoShare(id.clone());
+    let details: AutoShareDetails = env
+        .storage()
+        .persistent()
+        .get(&group_key)
+        .ok_or(Error::NotFound)?;
+    bump_persistent(&env, &group_key);
+
+    if !details.is_active {
+        return Err(Error::GroupInactive);
+    }
+
+    // Transfer tokens from depositor into the contract
+    let token_client = token::Client::new(&env, &token);
+    token_client.transfer(&depositor, &env.current_contract_address(), &amount);
+
+    // Update per-group, per-token treasury balance
+    let treasury_key = DataKey::GroupTreasury(id.clone(), token.clone());
+    let current_balance: i128 = env
+        .storage()
+        .persistent()
+        .get(&treasury_key)
+        .unwrap_or(0i128);
+    let new_balance = current_balance + amount;
+    env.storage().persistent().set(&treasury_key, &new_balance);
+    bump_persistent(&env, &treasury_key);
+
+    // Build deposit record
+    let record = DepositRecord {
+        group_id: id.clone(),
+        depositor: depositor.clone(),
+        token: token.clone(),
+        amount,
+        timestamp: env.ledger().timestamp(),
+    };
+
+    // Append to group deposit history
+    let group_hist_key = DataKey::GroupDepositHistory(id.clone());
+    let mut group_history: Vec<DepositRecord> = env
+        .storage()
+        .persistent()
+        .get(&group_hist_key)
+        .unwrap_or(Vec::new(&env));
+    group_history.push_back(record.clone());
+    env.storage()
+        .persistent()
+        .set(&group_hist_key, &group_history);
+    bump_persistent(&env, &group_hist_key);
+
+    // Append to depositor history
+    let depositor_hist_key = DataKey::DepositorHistory(depositor.clone());
+    let mut depositor_history: Vec<DepositRecord> = env
+        .storage()
+        .persistent()
+        .get(&depositor_hist_key)
+        .unwrap_or(Vec::new(&env));
+    depositor_history.push_back(record);
+    env.storage()
+        .persistent()
+        .set(&depositor_hist_key, &depositor_history);
+    bump_persistent(&env, &depositor_hist_key);
+
+    // Emit event
+    emit_funds_deposited(&env, id, depositor, token, amount, new_balance);
+
+    Ok(())
+}
+
+/// Returns the treasury balance for a specific `(group, token)` pair.
+/// Returns 0 if no deposits have been made yet.
+pub fn get_group_treasury_balance(env: Env, id: BytesN<32>, token: Address) -> i128 {
+    let key = DataKey::GroupTreasury(id, token);
+    let balance: i128 = env.storage().persistent().get(&key).unwrap_or(0i128);
+    if balance > 0 {
+        bump_persistent(&env, &key);
+    }
+    balance
+}
+
+/// Returns the full deposit history for a group (all tokens, all depositors).
+pub fn get_group_deposit_history(env: Env, id: BytesN<32>) -> Vec<DepositRecord> {
+    let key = DataKey::GroupDepositHistory(id);
+    let result: Option<Vec<DepositRecord>> = env.storage().persistent().get(&key);
+    if result.is_some() {
+        bump_persistent(&env, &key);
+    }
+    result.unwrap_or(Vec::new(&env))
+}
+
+/// Returns the full deposit history for a specific depositor across all groups.
+pub fn get_depositor_history(env: Env, depositor: Address) -> Vec<DepositRecord> {
+    let key = DataKey::DepositorHistory(depositor);
+    let result: Option<Vec<DepositRecord>> = env.storage().persistent().get(&key);
+    if result.is_some() {
+        bump_persistent(&env, &key);
+    }
+    result.unwrap_or(Vec::new(&env))
 }

--- a/contract/contracts/hello-world/src/base/events.rs
+++ b/contract/contracts/hello-world/src/base/events.rs
@@ -405,3 +405,34 @@ pub fn emit_member_added_to_group(
     }
     .publish(env);
 }
+
+#[contractevent]
+#[derive(Clone)]
+pub struct FundsDeposited {
+    #[topic]
+    pub group_id: BytesN<32>,
+    #[topic]
+    pub depositor: Address,
+    #[topic]
+    pub token: Address,
+    pub amount: i128,
+    pub new_treasury_balance: i128,
+}
+
+pub fn emit_funds_deposited(
+    env: &Env,
+    group_id: BytesN<32>,
+    depositor: Address,
+    token: Address,
+    amount: i128,
+    new_treasury_balance: i128,
+) {
+    FundsDeposited {
+        group_id,
+        depositor,
+        token,
+        amount,
+        new_treasury_balance,
+    }
+    .publish(env);
+}

--- a/contract/contracts/hello-world/src/base/types.rs
+++ b/contract/contracts/hello-world/src/base/types.rs
@@ -125,3 +125,13 @@ pub struct GroupSummary {
     pub has_active_fundraising: bool,
     pub total_distributions: u32,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DepositRecord {
+    pub group_id: BytesN<32>,
+    pub depositor: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+}

--- a/contract/contracts/hello-world/src/lib.rs
+++ b/contract/contracts/hello-world/src/lib.rs
@@ -437,7 +437,6 @@ impl AutoShareContract {
     pub fn set_usage_fee(env: Env, fee: u32, admin: Address) {
         autoshare_logic::set_usage_fee(env, fee, admin).unwrap();
     }
-
     /// Returns the current usage fee.
     pub fn get_usage_fee(env: Env) -> u32 {
         autoshare_logic::get_usage_fee(env)
@@ -716,6 +715,43 @@ impl AutoShareContract {
     pub fn cancel_fundraising(env: Env, id: BytesN<32>, caller: Address) {
         autoshare_logic::cancel_fundraising(env, id, caller).unwrap();
     }
+
+    // ============================================================================
+    // Treasury
+    // ============================================================================
+
+    /// Deposits `amount` of `token` into the group's treasury for future distributions.
+    /// The depositor must authorize the call. Group must be active and token supported.
+    pub fn deposit_funds(
+        env: Env,
+        id: BytesN<32>,
+        token: Address,
+        amount: i128,
+        depositor: Address,
+    ) {
+        autoshare_logic::deposit_funds(env, id, token, amount, depositor).unwrap();
+    }
+
+    /// Returns the treasury balance for a specific (group, token) pair.
+    pub fn get_group_treasury_balance(env: Env, id: BytesN<32>, token: Address) -> i128 {
+        autoshare_logic::get_group_treasury_balance(env, id, token)
+    }
+
+    /// Returns the full deposit history for a group.
+    pub fn get_group_deposit_history(
+        env: Env,
+        id: BytesN<32>,
+    ) -> Vec<base::types::DepositRecord> {
+        autoshare_logic::get_group_deposit_history(env, id)
+    }
+
+    /// Returns the full deposit history for a specific depositor across all groups.
+    pub fn get_depositor_history(
+        env: Env,
+        depositor: Address,
+    ) -> Vec<base::types::DepositRecord> {
+        autoshare_logic::get_depositor_history(env, depositor)
+    }
 }
 
 // 3. Link the tests (Requirement: Unit Tests)
@@ -890,3 +926,7 @@ mod set_protocol_fee_test;
 #[cfg(test)]
 #[path = "tests/update_payment_group_advanced_test.rs"]
 mod update_payment_group_advanced_test;
+
+#[cfg(test)]
+#[path = "tests/deposit_funds_test.rs"]
+mod deposit_funds_test;

--- a/contract/contracts/hello-world/src/lib.rs
+++ b/contract/contracts/hello-world/src/lib.rs
@@ -443,6 +443,22 @@ impl AutoShareContract {
         autoshare_logic::get_usage_fee(env)
     }
 
+    /// Sets the protocol fee percentage (0–100). Pass `group_id = None` for the global
+    /// default, or `Some(id)` to set a group-specific override. Admin only.
+    pub fn set_protocol_fee(
+        env: Env,
+        admin: Address,
+        fee_percent: u32,
+        group_id: Option<BytesN<32>>,
+    ) {
+        autoshare_logic::set_protocol_fee(env, admin, fee_percent, group_id).unwrap();
+    }
+
+    /// Returns the effective protocol fee percentage for a group (or the global default).
+    pub fn get_protocol_fee(env: Env, group_id: Option<BytesN<32>>) -> u32 {
+        autoshare_logic::get_protocol_fee(env, group_id)
+    }
+
     /// Sets the maximum number of members per group (admin only).
     pub fn set_max_members(env: Env, admin: Address, max: u32) {
         autoshare_logic::set_max_members(env, admin, max).unwrap();
@@ -866,3 +882,7 @@ mod update_payment_group_test;
 #[cfg(test)]
 #[path = "tests/update_payment_group_boundary_test.rs"]
 mod update_payment_group_boundary_test;
+
+#[cfg(test)]
+#[path = "tests/set_protocol_fee_test.rs"]
+mod set_protocol_fee_test;

--- a/contract/contracts/hello-world/src/lib.rs
+++ b/contract/contracts/hello-world/src/lib.rs
@@ -886,3 +886,7 @@ mod update_payment_group_boundary_test;
 #[cfg(test)]
 #[path = "tests/set_protocol_fee_test.rs"]
 mod set_protocol_fee_test;
+
+#[cfg(test)]
+#[path = "tests/update_payment_group_advanced_test.rs"]
+mod update_payment_group_advanced_test;

--- a/contract/contracts/hello-world/src/tests/deposit_funds_test.rs
+++ b/contract/contracts/hello-world/src/tests/deposit_funds_test.rs
@@ -1,0 +1,444 @@
+#![cfg(test)]
+#![allow(unused_imports)]
+
+use crate::test_utils::{deploy_autoshare_contract, deploy_mock_token, mint_tokens};
+use crate::AutoShareContractClient;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (Address, Address, AutoShareContractClient<'_>) {
+    let admin = Address::generate(env);
+    let contract_id = deploy_autoshare_contract(env, &admin);
+    let client = AutoShareContractClient::new(env, &contract_id);
+    client.initialize_admin(&admin);
+
+    let token = deploy_mock_token(
+        env,
+        &String::from_str(env, "Test Token"),
+        &String::from_str(env, "TEST"),
+    );
+    client.add_supported_token(&token, &admin);
+    (admin, token, client)
+}
+
+fn make_group(
+    env: &Env,
+    client: &AutoShareContractClient,
+    token: &Address,
+    creator: &Address,
+    seed: u8,
+) -> BytesN<32> {
+    let id = BytesN::from_array(env, &[seed; 32]);
+    mint_tokens(env, token, creator, 10_000);
+    client.create(&id, &String::from_str(env, "Test Group"), creator, &1, token);
+    id
+}
+
+// ─── Happy path ──────────────────────────────────────────────────────────────
+
+/// Basic deposit increases the treasury balance by the deposited amount.
+#[test]
+fn test_deposit_increases_treasury_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 1);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 500);
+
+    assert_eq!(client.get_group_treasury_balance(&id, &token), 0);
+    client.deposit_funds(&id, &token, &200, &depositor);
+    assert_eq!(client.get_group_treasury_balance(&id, &token), 200);
+}
+
+/// Multiple deposits from the same depositor accumulate correctly.
+#[test]
+fn test_multiple_deposits_accumulate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 2);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 1_000);
+
+    client.deposit_funds(&id, &token, &100, &depositor);
+    client.deposit_funds(&id, &token, &250, &depositor);
+    client.deposit_funds(&id, &token, &50, &depositor);
+
+    assert_eq!(client.get_group_treasury_balance(&id, &token), 400);
+}
+
+/// Deposits from different depositors all credit the same group treasury.
+#[test]
+fn test_deposits_from_different_depositors_accumulate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 3);
+
+    let d1 = Address::generate(&env);
+    let d2 = Address::generate(&env);
+    mint_tokens(&env, &token, &d1, 500);
+    mint_tokens(&env, &token, &d2, 500);
+
+    client.deposit_funds(&id, &token, &300, &d1);
+    client.deposit_funds(&id, &token, &150, &d2);
+
+    assert_eq!(client.get_group_treasury_balance(&id, &token), 450);
+}
+
+/// Deposit of exactly 1 (minimum valid amount) is accepted.
+#[test]
+fn test_deposit_minimum_amount_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 4);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 100);
+
+    client.deposit_funds(&id, &token, &1, &depositor);
+    assert_eq!(client.get_group_treasury_balance(&id, &token), 1);
+}
+
+/// Deposit of a very large amount is accepted (no artificial cap).
+#[test]
+fn test_deposit_large_amount_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 5);
+
+    let depositor = Address::generate(&env);
+    let large: i128 = 1_000_000_000_000;
+    mint_tokens(&env, &token, &depositor, large);
+
+    client.deposit_funds(&id, &token, &large, &depositor);
+    assert_eq!(client.get_group_treasury_balance(&id, &token), large);
+}
+
+// ─── History recording ───────────────────────────────────────────────────────
+
+/// Each deposit is appended to the group's deposit history.
+#[test]
+fn test_deposit_appended_to_group_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 6);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 1_000);
+
+    client.deposit_funds(&id, &token, &100, &depositor);
+    client.deposit_funds(&id, &token, &200, &depositor);
+
+    let history = client.get_group_deposit_history(&id);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().amount, 100);
+    assert_eq!(history.get(1).unwrap().amount, 200);
+}
+
+/// Each deposit is appended to the depositor's personal history.
+#[test]
+fn test_deposit_appended_to_depositor_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 7);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 1_000);
+
+    client.deposit_funds(&id, &token, &75, &depositor);
+    client.deposit_funds(&id, &token, &125, &depositor);
+
+    let history = client.get_depositor_history(&depositor);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().amount, 75);
+    assert_eq!(history.get(1).unwrap().amount, 125);
+}
+
+/// Deposit records carry the correct group_id, depositor, token, and amount.
+#[test]
+fn test_deposit_record_fields_are_correct() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 8);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 500);
+
+    client.deposit_funds(&id, &token, &333, &depositor);
+
+    let record = client.get_group_deposit_history(&id).get(0).unwrap();
+    assert_eq!(record.group_id, id);
+    assert_eq!(record.depositor, depositor);
+    assert_eq!(record.token, token);
+    assert_eq!(record.amount, 333);
+}
+
+/// Depositor history across two different groups is tracked independently.
+#[test]
+fn test_depositor_history_spans_multiple_groups() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id_a = make_group(&env, &client, &token, &creator, 9);
+    let id_b = make_group(&env, &client, &token, &creator, 10);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 1_000);
+
+    client.deposit_funds(&id_a, &token, &100, &depositor);
+    client.deposit_funds(&id_b, &token, &200, &depositor);
+
+    let history = client.get_depositor_history(&depositor);
+    assert_eq!(history.len(), 2);
+}
+
+// ─── Treasury isolation ──────────────────────────────────────────────────────
+
+/// Depositing into group A does not affect group B's treasury.
+#[test]
+fn test_deposit_does_not_bleed_into_sibling_group() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id_a = make_group(&env, &client, &token, &creator, 11);
+    let id_b = make_group(&env, &client, &token, &creator, 12);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 500);
+
+    client.deposit_funds(&id_a, &token, &400, &depositor);
+
+    assert_eq!(client.get_group_treasury_balance(&id_a, &token), 400);
+    assert_eq!(client.get_group_treasury_balance(&id_b, &token), 0);
+}
+
+/// Two different tokens deposited into the same group are tracked separately.
+#[test]
+fn test_two_tokens_tracked_independently_in_same_group() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token_a, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token_a, &creator, 13);
+
+    // Register a second token
+    let token_b = deploy_mock_token(
+        &env,
+        &String::from_str(&env, "Token B"),
+        &String::from_str(&env, "TKNB"),
+    );
+    client.add_supported_token(&token_b, &admin);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token_a, &depositor, 1_000);
+    mint_tokens(&env, &token_b, &depositor, 1_000);
+
+    client.deposit_funds(&id, &token_a, &300, &depositor);
+    client.deposit_funds(&id, &token_b, &700, &depositor);
+
+    assert_eq!(client.get_group_treasury_balance(&id, &token_a), 300);
+    assert_eq!(client.get_group_treasury_balance(&id, &token_b), 700);
+}
+
+// ─── Error conditions ────────────────────────────────────────────────────────
+
+/// Amount of zero is rejected with InvalidAmount.
+#[test]
+#[should_panic(expected = "InvalidAmount")]
+fn test_deposit_zero_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 14);
+
+    let depositor = Address::generate(&env);
+    client.deposit_funds(&id, &token, &0, &depositor);
+}
+
+/// Negative amount is rejected with InvalidAmount.
+#[test]
+#[should_panic(expected = "InvalidAmount")]
+fn test_deposit_negative_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 15);
+
+    let depositor = Address::generate(&env);
+    client.deposit_funds(&id, &token, &-1, &depositor);
+}
+
+/// Depositing into a non-existent group is rejected with NotFound.
+#[test]
+#[should_panic(expected = "NotFound")]
+fn test_deposit_nonexistent_group_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 500);
+    let ghost_id = BytesN::from_array(&env, &[0xFFu8; 32]);
+
+    client.deposit_funds(&ghost_id, &token, &100, &depositor);
+}
+
+/// Depositing into an inactive group is rejected with GroupInactive.
+#[test]
+#[should_panic(expected = "GroupInactive")]
+fn test_deposit_inactive_group_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 16);
+
+    client.deactivate_payment_group(&id, &creator);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 500);
+    client.deposit_funds(&id, &token, &100, &depositor);
+}
+
+/// Depositing with an unsupported token is rejected with UnsupportedToken.
+#[test]
+#[should_panic(expected = "UnsupportedToken")]
+fn test_deposit_unsupported_token_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 17);
+
+    // Deploy a token but do NOT add it to the supported list
+    let bad_token = deploy_mock_token(
+        &env,
+        &String::from_str(&env, "Bad Token"),
+        &String::from_str(&env, "BAD"),
+    );
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &bad_token, &depositor, 500);
+    client.deposit_funds(&id, &bad_token, &100, &depositor);
+}
+
+/// Depositing while the contract is paused is rejected with ContractPaused.
+#[test]
+#[should_panic(expected = "ContractPaused")]
+fn test_deposit_while_paused_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 18);
+
+    client.pause(&admin);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 500);
+    client.deposit_funds(&id, &token, &100, &depositor);
+}
+
+// ─── State revert on error ───────────────────────────────────────────────────
+
+/// A failed deposit must not mutate the treasury balance.
+#[test]
+fn test_failed_deposit_does_not_mutate_treasury() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 19);
+
+    // Successful deposit first
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 500);
+    client.deposit_funds(&id, &token, &100, &depositor);
+    assert_eq!(client.get_group_treasury_balance(&id, &token), 100);
+
+    // Attempt zero-amount deposit — must fail
+    let result = client.try_deposit_funds(&id, &token, &0, &depositor);
+    assert!(result.is_err());
+
+    // Treasury must be unchanged
+    assert_eq!(client.get_group_treasury_balance(&id, &token), 100);
+}
+
+/// A failed deposit must not append to the group deposit history.
+#[test]
+fn test_failed_deposit_does_not_append_to_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 20);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 500);
+    client.deposit_funds(&id, &token, &50, &depositor);
+
+    // Attempt invalid deposit
+    let _ = client.try_deposit_funds(&id, &token, &-10, &depositor);
+
+    assert_eq!(client.get_group_deposit_history(&id).len(), 1);
+}
+
+// ─── Post-reactivation ───────────────────────────────────────────────────────
+
+/// Deposit succeeds after a group is deactivated then reactivated.
+#[test]
+fn test_deposit_after_reactivation_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 21);
+
+    client.deactivate_payment_group(&id, &creator);
+    client.activate_group(&id, &creator);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 500);
+    client.deposit_funds(&id, &token, &200, &depositor);
+    assert_eq!(client.get_group_treasury_balance(&id, &token), 200);
+}
+
+/// Deposit succeeds after the contract is unpaused.
+#[test]
+fn test_deposit_after_unpause_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 22);
+
+    client.pause(&admin);
+    client.unpause(&admin);
+
+    let depositor = Address::generate(&env);
+    mint_tokens(&env, &token, &depositor, 500);
+    client.deposit_funds(&id, &token, &150, &depositor);
+    assert_eq!(client.get_group_treasury_balance(&id, &token), 150);
+}

--- a/contract/contracts/hello-world/src/tests/set_protocol_fee_test.rs
+++ b/contract/contracts/hello-world/src/tests/set_protocol_fee_test.rs
@@ -1,0 +1,223 @@
+#![allow(unused_imports)]
+
+use crate::test_utils::deploy_autoshare_contract;
+use crate::AutoShareContractClient;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (Address, AutoShareContractClient<'_>) {
+    let admin = Address::generate(env);
+    let contract_id = deploy_autoshare_contract(env, &admin);
+    let client = AutoShareContractClient::new(env, &contract_id);
+    client.initialize_admin(&admin);
+    (admin, client)
+}
+
+fn group_id(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+// ─── Global fee ──────────────────────────────────────────────────────────────
+
+/// Default global protocol fee is 0 before any admin sets it.
+#[test]
+fn test_global_protocol_fee_defaults_to_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    assert_eq!(client.get_protocol_fee(&None), 0);
+}
+
+/// Admin can set the global protocol fee to a valid percentage.
+#[test]
+fn test_admin_can_set_global_protocol_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    client.set_protocol_fee(&admin, &5, &None);
+    assert_eq!(client.get_protocol_fee(&None), 5);
+}
+
+/// Admin can update the global protocol fee multiple times.
+#[test]
+fn test_admin_can_update_global_protocol_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    client.set_protocol_fee(&admin, &10, &None);
+    assert_eq!(client.get_protocol_fee(&None), 10);
+
+    client.set_protocol_fee(&admin, &25, &None);
+    assert_eq!(client.get_protocol_fee(&None), 25);
+}
+
+/// Admin can set the global protocol fee to 0 (fee-free).
+#[test]
+fn test_admin_can_set_global_fee_to_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    client.set_protocol_fee(&admin, &20, &None);
+    client.set_protocol_fee(&admin, &0, &None);
+    assert_eq!(client.get_protocol_fee(&None), 0);
+}
+
+/// Admin can set the global protocol fee to the maximum (100%).
+#[test]
+fn test_admin_can_set_global_fee_to_100() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    client.set_protocol_fee(&admin, &100, &None);
+    assert_eq!(client.get_protocol_fee(&None), 100);
+}
+
+/// Setting a fee above 100 is rejected with InvalidInput.
+#[test]
+#[should_panic(expected = "InvalidInput")]
+fn test_global_fee_above_100_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    client.set_protocol_fee(&admin, &101, &None);
+}
+
+/// Non-admin cannot set the global protocol fee.
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_non_admin_cannot_set_global_protocol_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let non_admin = Address::generate(&env);
+    client.set_protocol_fee(&non_admin, &5, &None);
+}
+
+// ─── Group-specific fee ──────────────────────────────────────────────────────
+
+/// Admin can set a group-specific protocol fee override.
+#[test]
+fn test_admin_can_set_group_specific_protocol_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let id = group_id(&env, 1);
+    client.set_protocol_fee(&admin, &15, &Some(id.clone()));
+    assert_eq!(client.get_protocol_fee(&Some(id)), 15);
+}
+
+/// Group-specific fee overrides the global fee for that group.
+#[test]
+fn test_group_fee_overrides_global_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    // Set global fee
+    client.set_protocol_fee(&admin, &10, &None);
+
+    // Override for group 1
+    let id = group_id(&env, 1);
+    client.set_protocol_fee(&admin, &3, &Some(id.clone()));
+
+    // Group 1 uses its own override
+    assert_eq!(client.get_protocol_fee(&Some(id)), 3);
+    // Global fee is unchanged
+    assert_eq!(client.get_protocol_fee(&None), 10);
+}
+
+/// A group without an override falls back to the global fee.
+#[test]
+fn test_group_without_override_falls_back_to_global() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    client.set_protocol_fee(&admin, &8, &None);
+
+    // group 2 has no override — should return global fee
+    let id = group_id(&env, 2);
+    assert_eq!(client.get_protocol_fee(&Some(id)), 8);
+}
+
+/// Different groups can have independent fee overrides.
+#[test]
+fn test_independent_group_fee_overrides() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let id1 = group_id(&env, 1);
+    let id2 = group_id(&env, 2);
+
+    client.set_protocol_fee(&admin, &5, &Some(id1.clone()));
+    client.set_protocol_fee(&admin, &20, &Some(id2.clone()));
+
+    assert_eq!(client.get_protocol_fee(&Some(id1)), 5);
+    assert_eq!(client.get_protocol_fee(&Some(id2)), 20);
+}
+
+/// Admin can update a group-specific fee multiple times.
+#[test]
+fn test_admin_can_update_group_specific_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let id = group_id(&env, 1);
+    client.set_protocol_fee(&admin, &10, &Some(id.clone()));
+    assert_eq!(client.get_protocol_fee(&Some(id.clone())), 10);
+
+    client.set_protocol_fee(&admin, &50, &Some(id.clone()));
+    assert_eq!(client.get_protocol_fee(&Some(id)), 50);
+}
+
+/// Group-specific fee above 100 is rejected with InvalidInput.
+#[test]
+#[should_panic(expected = "InvalidInput")]
+fn test_group_fee_above_100_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let id = group_id(&env, 1);
+    client.set_protocol_fee(&admin, &101, &Some(id));
+}
+
+/// Non-admin cannot set a group-specific protocol fee.
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_non_admin_cannot_set_group_specific_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let non_admin = Address::generate(&env);
+    let id = group_id(&env, 1);
+    client.set_protocol_fee(&non_admin, &5, &Some(id));
+}
+
+/// Setting a group fee to 0 explicitly overrides the global fee with zero.
+#[test]
+fn test_group_fee_zero_overrides_global() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    client.set_protocol_fee(&admin, &20, &None);
+
+    let id = group_id(&env, 1);
+    client.set_protocol_fee(&admin, &0, &Some(id.clone()));
+
+    // Group explicitly has 0% fee even though global is 20%
+    assert_eq!(client.get_protocol_fee(&Some(id)), 0);
+}

--- a/contract/contracts/hello-world/src/tests/update_payment_group_advanced_test.rs
+++ b/contract/contracts/hello-world/src/tests/update_payment_group_advanced_test.rs
@@ -1,0 +1,563 @@
+#![cfg(test)]
+#![allow(unused_imports)]
+
+use crate::test_utils::{
+    create_test_group, create_test_members, deploy_autoshare_contract, deploy_mock_token,
+    mint_tokens, setup_test_env,
+};
+use crate::AutoShareContractClient;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (Address, Address, AutoShareContractClient<'_>) {
+    let admin = Address::generate(env);
+    let contract_id = deploy_autoshare_contract(env, &admin);
+    let client = AutoShareContractClient::new(env, &contract_id);
+    client.initialize_admin(&admin);
+
+    let token = deploy_mock_token(
+        env,
+        &String::from_str(env, "Test Token"),
+        &String::from_str(env, "TEST"),
+    );
+    client.add_supported_token(&token, &admin);
+    (admin, token, client)
+}
+
+fn make_group(
+    env: &Env,
+    client: &AutoShareContractClient,
+    token: &Address,
+    creator: &Address,
+    seed: u8,
+) -> BytesN<32> {
+    let id = BytesN::from_array(env, &[seed; 32]);
+    mint_tokens(env, token, creator, 10_000);
+    client.create(&id, &String::from_str(env, "Initial Name"), creator, &1, token);
+    id
+}
+
+// ─── Name boundary ──────────────────────────────────────────────────────────
+
+/// Exactly 60 characters — the maximum valid name length.
+#[test]
+fn test_name_at_exact_max_length_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 1);
+
+    let name_60 = String::from_str(&env, &"X".repeat(60));
+    client.update_payment_group(&id, &creator, &Some(name_60.clone()), &None, &None);
+    assert_eq!(client.get(&id).name, name_60);
+}
+
+/// 61 characters — one over the limit — must be rejected.
+#[test]
+#[should_panic(expected = "EmptyName")]
+fn test_name_one_over_max_length_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 2);
+
+    let name_61 = String::from_str(&env, &"X".repeat(61));
+    client.update_payment_group(&id, &creator, &Some(name_61), &None, &None);
+}
+
+/// Extremely long name (1 KB) must be rejected.
+#[test]
+#[should_panic(expected = "EmptyName")]
+fn test_name_extreme_overflow_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 3);
+
+    let huge_name = String::from_str(&env, &"A".repeat(1024));
+    client.update_payment_group(&id, &creator, &Some(huge_name), &None, &None);
+}
+
+/// Single character name — minimum valid non-whitespace name.
+#[test]
+fn test_name_single_char_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 4);
+
+    let name = String::from_str(&env, "Z");
+    client.update_payment_group(&id, &creator, &Some(name.clone()), &None, &None);
+    assert_eq!(client.get(&id).name, name);
+}
+
+/// Empty string name must be rejected.
+#[test]
+#[should_panic(expected = "EmptyName")]
+fn test_name_empty_string_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 5);
+
+    client.update_payment_group(&id, &creator, &Some(String::from_str(&env, "")), &None, &None);
+}
+
+/// Whitespace-only name (spaces) must be rejected.
+#[test]
+#[should_panic(expected = "EmptyName")]
+fn test_name_spaces_only_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 6);
+
+    client.update_payment_group(&id, &creator, &Some(String::from_str(&env, "     ")), &None, &None);
+}
+
+/// Tab-only name must be rejected.
+#[test]
+#[should_panic(expected = "EmptyName")]
+fn test_name_tabs_only_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 7);
+
+    client.update_payment_group(&id, &creator, &Some(String::from_str(&env, "\t\t\t")), &None, &None);
+}
+
+/// Name with leading/trailing whitespace but a valid inner character is accepted.
+#[test]
+fn test_name_with_surrounding_whitespace_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 8);
+
+    let name = String::from_str(&env, "  valid  ");
+    client.update_payment_group(&id, &creator, &Some(name.clone()), &None, &None);
+    assert_eq!(client.get(&id).name, name);
+}
+
+// ─── State revert on invalid input ──────────────────────────────────────────
+
+/// When name update fails, the original name must be preserved (no partial write).
+#[test]
+fn test_failed_name_update_does_not_mutate_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 9);
+
+    let original_name = client.get(&id).name.clone();
+
+    // Attempt invalid update — should panic
+    let result = client.try_update_payment_group(
+        &id,
+        &creator,
+        &Some(String::from_str(&env, "")), // invalid
+        &None,
+        &None,
+    );
+    assert!(result.is_err());
+
+    // State must be unchanged
+    assert_eq!(client.get(&id).name, original_name);
+}
+
+/// Unauthorized caller must not mutate any field.
+#[test]
+fn test_unauthorized_update_does_not_mutate_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 10);
+
+    let before = client.get(&id);
+
+    let result = client.try_update_payment_group(
+        &id,
+        &attacker,
+        &Some(String::from_str(&env, "Hijacked")),
+        &Some(String::from_str(&env, "evil metadata")),
+        &Some(attacker.clone()),
+    );
+    assert!(result.is_err());
+
+    let after = client.get(&id);
+    assert_eq!(before.name, after.name);
+    assert_eq!(before.metadata, after.metadata);
+    assert_eq!(before.creator, after.creator);
+}
+
+/// Update on a non-existent group ID must not create a new group.
+#[test]
+fn test_update_nonexistent_group_does_not_create_entry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, _, client) = setup(&env);
+    let caller = Address::generate(&env);
+    let ghost_id = BytesN::from_array(&env, &[0xFFu8; 32]);
+
+    let result = client.try_update_payment_group(
+        &ghost_id,
+        &caller,
+        &Some(String::from_str(&env, "Ghost")),
+        &None,
+        &None,
+    );
+    assert!(result.is_err());
+
+    // Confirm the group was not created
+    let fetch = client.try_get(&ghost_id);
+    assert!(fetch.is_err());
+}
+
+// ─── Admin rotation edge cases ───────────────────────────────────────────────
+
+/// Rotating ownership to self is a no-op — creator stays the same.
+#[test]
+fn test_admin_rotation_to_self_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 11);
+
+    client.update_payment_group(&id, &creator, &None, &None, &Some(creator.clone()));
+    assert_eq!(client.get(&id).creator, creator);
+}
+
+/// After rotation, the old creator must be fully locked out.
+#[test]
+fn test_old_creator_locked_out_after_rotation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 12);
+
+    client.update_payment_group(&id, &creator, &None, &None, &Some(new_owner.clone()));
+
+    // Old creator can no longer update
+    let result = client.try_update_payment_group(
+        &id,
+        &creator,
+        &Some(String::from_str(&env, "Reclaim")),
+        &None,
+        &None,
+    );
+    assert!(result.is_err());
+}
+
+/// New creator can immediately update after rotation.
+#[test]
+fn test_new_creator_can_update_immediately_after_rotation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 13);
+
+    client.update_payment_group(&id, &creator, &None, &None, &Some(new_owner.clone()));
+
+    let updated_name = String::from_str(&env, "New Owner Update");
+    client.update_payment_group(&id, &new_owner, &Some(updated_name.clone()), &None, &None);
+    assert_eq!(client.get(&id).name, updated_name);
+}
+
+/// Chained rotation: A → B → C, only C should be the final owner.
+#[test]
+fn test_chained_admin_rotation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &a, 14);
+
+    client.update_payment_group(&id, &a, &None, &None, &Some(b.clone()));
+    assert_eq!(client.get(&id).creator, b);
+
+    client.update_payment_group(&id, &b, &None, &None, &Some(c.clone()));
+    assert_eq!(client.get(&id).creator, c);
+
+    // A and B are both locked out
+    assert!(client.try_update_payment_group(&id, &a, &None, &None, &None).is_err());
+    assert!(client.try_update_payment_group(&id, &b, &None, &None, &None).is_err());
+}
+
+// ─── Simultaneous field updates ──────────────────────────────────────────────
+
+/// All three fields updated in one call — all must be persisted atomically.
+#[test]
+fn test_all_fields_updated_atomically() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 15);
+
+    let new_name = String::from_str(&env, "Atomic Name");
+    let new_meta = String::from_str(&env, "Atomic Meta");
+
+    client.update_payment_group(
+        &id,
+        &creator,
+        &Some(new_name.clone()),
+        &Some(new_meta.clone()),
+        &Some(new_owner.clone()),
+    );
+
+    let details = client.get(&id);
+    assert_eq!(details.name, new_name);
+    assert_eq!(details.metadata, new_meta);
+    assert_eq!(details.creator, new_owner);
+}
+
+/// Passing all None fields must leave every field unchanged.
+#[test]
+fn test_all_none_fields_is_true_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 16);
+
+    // Set known state first
+    let known_name = String::from_str(&env, "Known Name");
+    let known_meta = String::from_str(&env, "Known Meta");
+    client.update_payment_group(&id, &creator, &Some(known_name.clone()), &Some(known_meta.clone()), &None);
+
+    // Now call with all None
+    client.update_payment_group(&id, &creator, &None, &None, &None);
+
+    let details = client.get(&id);
+    assert_eq!(details.name, known_name);
+    assert_eq!(details.metadata, known_meta);
+    assert_eq!(details.creator, creator);
+}
+
+// ─── Rapid successive updates ────────────────────────────────────────────────
+
+/// Ten sequential name updates — only the last value must be stored.
+#[test]
+fn test_rapid_successive_name_updates_last_wins() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 17);
+
+    let names = [
+        "Name 0", "Name 1", "Name 2", "Name 3", "Name 4",
+        "Name 5", "Name 6", "Name 7", "Name 8", "Name 9",
+    ];
+    for name_str in names.iter() {
+        let name = String::from_str(&env, name_str);
+        client.update_payment_group(&id, &creator, &Some(name), &None, &None);
+    }
+
+    assert_eq!(client.get(&id).name, String::from_str(&env, "Name 9"));
+}
+
+// ─── Metadata edge cases ─────────────────────────────────────────────────────
+
+/// Empty metadata string is accepted (no validation constraint on metadata).
+#[test]
+fn test_metadata_empty_string_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 18);
+
+    let empty_meta = String::from_str(&env, "");
+    client.update_payment_group(&id, &creator, &None, &Some(empty_meta.clone()), &None);
+    assert_eq!(client.get(&id).metadata, empty_meta);
+}
+
+/// Very large metadata (4 KB) is accepted — no size cap on metadata.
+#[test]
+fn test_metadata_4kb_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 19);
+
+    let large_meta = String::from_str(&env, &"M".repeat(4096));
+    client.update_payment_group(&id, &creator, &None, &Some(large_meta.clone()), &None);
+    assert_eq!(client.get(&id).metadata, large_meta);
+}
+
+/// Metadata with special characters (JSON-like) is stored verbatim.
+#[test]
+fn test_metadata_special_characters_stored_verbatim() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 20);
+
+    let special = String::from_str(&env, r#"{"key":"value","n":42,"arr":[1,2,3]}"#);
+    client.update_payment_group(&id, &creator, &None, &Some(special.clone()), &None);
+    assert_eq!(client.get(&id).metadata, special);
+}
+
+/// Overwriting metadata with a shorter string does not leave stale data.
+#[test]
+fn test_metadata_overwrite_shorter_value_no_stale_data() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 21);
+
+    let long_meta = String::from_str(&env, &"L".repeat(500));
+    client.update_payment_group(&id, &creator, &None, &Some(long_meta), &None);
+
+    let short_meta = String::from_str(&env, "short");
+    client.update_payment_group(&id, &creator, &None, &Some(short_meta.clone()), &None);
+
+    assert_eq!(client.get(&id).metadata, short_meta);
+}
+
+// ─── Paused / inactive state reverts ────────────────────────────────────────
+
+/// Update while paused must not persist any field change.
+#[test]
+fn test_update_while_paused_does_not_mutate_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 22);
+
+    let before = client.get(&id);
+    client.pause(&admin);
+
+    let result = client.try_update_payment_group(
+        &id,
+        &creator,
+        &Some(String::from_str(&env, "Paused Update")),
+        &None,
+        &None,
+    );
+    assert!(result.is_err());
+
+    client.unpause(&admin);
+    let after = client.get(&id);
+    assert_eq!(before.name, after.name);
+}
+
+/// Update on an inactive group must not persist any field change.
+#[test]
+fn test_update_inactive_group_does_not_mutate_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 23);
+
+    let before = client.get(&id);
+    client.deactivate_payment_group(&id, &creator);
+
+    let result = client.try_update_payment_group(
+        &id,
+        &creator,
+        &Some(String::from_str(&env, "Inactive Update")),
+        &None,
+        &None,
+    );
+    assert!(result.is_err());
+
+    // Reactivate to read state
+    client.activate_group(&id, &creator);
+    let after = client.get(&id);
+    assert_eq!(before.name, after.name);
+}
+
+// ─── Cross-group isolation ───────────────────────────────────────────────────
+
+/// Updating one group must not affect a sibling group's fields.
+#[test]
+fn test_update_does_not_bleed_into_sibling_group() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let id_a = make_group(&env, &client, &token, &creator, 24);
+    let id_b = make_group(&env, &client, &token, &creator, 25);
+
+    let before_b = client.get(&id_b);
+
+    client.update_payment_group(
+        &id_a,
+        &creator,
+        &Some(String::from_str(&env, "Group A Updated")),
+        &Some(String::from_str(&env, "Meta A")),
+        &None,
+    );
+
+    let after_b = client.get(&id_b);
+    assert_eq!(before_b.name, after_b.name);
+    assert_eq!(before_b.metadata, after_b.metadata);
+    assert_eq!(before_b.creator, after_b.creator);
+}
+
+// ─── Reactivation after deactivation ────────────────────────────────────────
+
+/// Group can be updated after being deactivated then reactivated.
+#[test]
+fn test_update_after_reactivation_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 26);
+
+    client.deactivate_payment_group(&id, &creator);
+    client.activate_group(&id, &creator);
+
+    let new_name = String::from_str(&env, "Post-Reactivation");
+    client.update_payment_group(&id, &creator, &Some(new_name.clone()), &None, &None);
+    assert_eq!(client.get(&id).name, new_name);
+}
+
+// ─── Unpause then update ─────────────────────────────────────────────────────
+
+/// Update must succeed after the contract is unpaused.
+#[test]
+fn test_update_after_unpause_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 27);
+
+    client.pause(&admin);
+    client.unpause(&admin);
+
+    let new_name = String::from_str(&env, "Post-Unpause");
+    client.update_payment_group(&id, &creator, &Some(new_name.clone()), &None, &None);
+    assert_eq!(client.get(&id).name, new_name);
+}


### PR DESCRIPTION
Add unit tests for the set_protocol_fee function covering updating the global or group-specific protocol fee configuration percentage. The tests should verify successful execution and test basic error conditions (e.g., unauthorized access, invalid inputs). Add the tests in a corresponding *_test.rs file.

Close #287