### PR TITLE
feat: implement protocol fees and advanced boundary testing (Fix #283, #294, #293, #290)

### DIFF
--- a/contract/README.md
+++ b/contract/README.md
@@ -95,3 +95,33 @@ These events are essential for the frontend transaction history page and analyti
 - If you initialized this project with any other example contracts via `--with-example`, those contracts will be in the `contracts` directory as well.
 - Contracts should have their own `Cargo.toml` files that rely on the top-level `Cargo.toml` workspace for their dependencies.
 - Frontend libraries can be added to the top-level directory as well. If you initialized this project with a frontend template via `--frontend-template` you will have those files already included.
+
+---
+
+## Protocol Configuration
+
+### set_protocol_fee
+
+Updates the global protocol fee percentage and the recipient address. Only the contract admin can call this function.
+
+**Arguments:**
+- `fee`: New fee in basis points (0–10000, where 10000 = 100%).
+- `recipient`: The `Address` that will receive protocol-level fees.
+- `admin`: The current contract admin address (must authorize).
+
+**Events:**
+- Emits `ProtocolFeeUpdated { admin, old_fee, new_fee, old_recipient, new_recipient }`.
+
+**Panics:**
+- If `admin` is not the authorized contract administrator.
+- If `fee` exceeds 10000 bps.
+
+### get_protocol_fee
+
+Returns the current protocol fee percentage and recipient address.
+
+**Returns:**
+- `(u32, Address)`: The current fee in basis points and the recipient address.
+
+**Diagnostics:**
+- Emits `ProtocolFeeRead { fee, recipient }` on every invocation for off-chain analytics and usage tracking.

--- a/contract/contracts/hello-world/src/autoshare_logic.rs
+++ b/contract/contracts/hello-world/src/autoshare_logic.rs
@@ -38,6 +38,8 @@ pub enum DataKey {
     MinContribution,
     // Diagnostic: per-group invocation counter for get_group_members
     GroupMembersQueryCount(BytesN<32>),
+    ProtocolFee,
+    ProtocolFeeRecipient,
 }
 
 const DAY_IN_LEDGERS: u32 = 17280;
@@ -3290,4 +3292,68 @@ pub fn cancel_fundraising(env: Env, id: BytesN<32>, caller: Address) -> Result<(
     emit_fundraising_cancelled(&env, id.clone(), total_raised_at_cancellation);
 
     Ok(())
+}
+
+pub fn get_protocol_fee(env: Env) -> (u32, Address) {
+    let fee = get_protocol_fee_val(&env);
+    let recipient = get_protocol_recipient_val(&env);
+    (fee, recipient)
+}
+
+pub fn set_protocol_fee(env: Env, fee: u32, recipient: Address, admin: Address) -> Result<(), Error> {
+    admin.require_auth();
+    require_admin(&env, &admin)?;
+
+    if fee > 10000 {
+        return Err(Error::InvalidInput);
+    }
+
+    let old_fee = get_protocol_fee_val(&env);
+    let old_recipient = get_protocol_recipient_val(&env);
+
+    let fee_key = DataKey::ProtocolFee;
+    let recipient_key = DataKey::ProtocolFeeRecipient;
+
+    env.storage().persistent().set(&fee_key, &fee);
+    env.storage().persistent().set(&recipient_key, &recipient);
+
+    bump_persistent(&env, &fee_key);
+    bump_persistent(&env, &recipient_key);
+
+    crate::base::events::emit_protocol_fee_updated(
+        &env,
+        admin,
+        old_fee,
+        fee,
+        old_recipient,
+        recipient,
+    );
+
+    Ok(())
+}
+
+fn get_protocol_fee_val(env: &Env) -> u32 {
+    let key = DataKey::ProtocolFee;
+    let fee = env.storage().persistent().get(&key).unwrap_or(0u32);
+    if env.storage().persistent().has(&key) {
+        bump_persistent(env, &key);
+    }
+    fee
+}
+
+fn get_protocol_recipient_val(env: &Env) -> Address {
+    let key = DataKey::ProtocolFeeRecipient;
+    // Default to admin if not set
+    let admin_key = DataKey::Admin;
+    let admin = env
+        .storage()
+        .persistent()
+        .get(&admin_key)
+        .expect("admin must be set");
+
+    let recipient = env.storage().persistent().get(&key).unwrap_or(admin);
+    if env.storage().persistent().has(&key) {
+        bump_persistent(env, &key);
+    }
+    recipient
 }

--- a/contract/contracts/hello-world/src/base/events.rs
+++ b/contract/contracts/hello-world/src/base/events.rs
@@ -439,3 +439,44 @@ pub fn emit_group_members_queried(
     }
     .publish(env);
 }
+
+#[contractevent]
+#[derive(Clone)]
+pub struct ProtocolFeeUpdated {
+    #[topic]
+    pub admin: Address,
+    pub old_fee: u32,
+    pub new_fee: u32,
+    pub old_recipient: Address,
+    pub new_recipient: Address,
+}
+
+pub fn emit_protocol_fee_updated(
+    env: &Env,
+    admin: Address,
+    old_fee: u32,
+    new_fee: u32,
+    old_recipient: Address,
+    new_recipient: Address,
+) {
+    ProtocolFeeUpdated {
+        admin,
+        old_fee,
+        new_fee,
+        old_recipient,
+        new_recipient,
+    }
+    .publish(env);
+}
+
+/// Emitted every time `get_protocol_fee` is invoked for analytics.
+#[contractevent]
+#[derive(Clone)]
+pub struct ProtocolFeeRead {
+    pub fee: u32,
+    pub recipient: Address,
+}
+
+pub fn emit_protocol_fee_read(env: &Env, fee: u32, recipient: Address) {
+    ProtocolFeeRead { fee, recipient }.publish(env);
+}

--- a/contract/contracts/hello-world/src/interfaces/autoshare.rs
+++ b/contract/contracts/hello-world/src/interfaces/autoshare.rs
@@ -338,4 +338,14 @@ pub trait AutoShareTrait {
 
     /// Cancels an active fundraising campaign. Only the group creator can cancel.
     fn cancel_fundraising(env: Env, id: BytesN<32>, caller: Address);
+
+    // ============================================================================
+    // Protocol Configuration
+    // ============================================================================
+
+    /// Returns the current protocol fee percentage (in basis points) and the fee recipient.
+    fn get_protocol_fee(env: Env) -> (u32, Address);
+
+    /// Sets the protocol fee and recipient address (admin only).
+    fn set_protocol_fee(env: Env, fee: u32, recipient: Address, admin: Address);
 }

--- a/contract/contracts/hello-world/src/lib.rs
+++ b/contract/contracts/hello-world/src/lib.rs
@@ -706,6 +706,39 @@ impl AutoShareContract {
     pub fn cancel_fundraising(env: Env, id: BytesN<32>, caller: Address) {
         autoshare_logic::cancel_fundraising(env, id, caller).unwrap();
     }
+
+    // ============================================================================
+    // Protocol Configuration
+    // ============================================================================
+
+    /// Returns the current protocol fee percentage (in basis points) and the fee recipient.
+    ///
+    /// This is a read-only operation that tracks invocations for off-chain analytics.
+    pub fn get_protocol_fee(env: Env) -> (u32, Address) {
+        let (fee, recipient) = autoshare_logic::get_protocol_fee(env.clone());
+
+        // Internal analytics: track read invocation (Issue #294)
+        crate::base::events::emit_protocol_fee_read(&env, fee, recipient.clone());
+
+        (fee, recipient)
+    }
+
+    /// Sets the protocol fee and recipient address (admin only).
+    /// Add comprehensive Rustdoc (Issue #290).
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    /// * `fee` - New fee in basis points (max 10000).
+    /// * `recipient` - New address to receive protocol fees.
+    /// * `admin` - Current contract admin address. Must authorize.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the caller is not the admin or if the fee exceeds 10000 bps.
+    pub fn set_protocol_fee(env: Env, fee: u32, recipient: Address, admin: Address) {
+        autoshare_logic::set_protocol_fee(env, fee, recipient, admin).unwrap();
+    }
 }
 
 // 3. Link the tests (Requirement: Unit Tests)
@@ -876,3 +909,11 @@ mod update_payment_group_boundary_test;
 #[cfg(test)]
 #[path = "tests/get_group_members_diagnostics_test.rs"]
 mod get_group_members_diagnostics_test;
+
+#[cfg(test)]
+#[path = "tests/get_group_members_boundary_test.rs"]
+mod get_group_members_boundary_test;
+
+#[cfg(test)]
+#[path = "tests/protocol_fee_boundary_test.rs"]
+mod protocol_fee_boundary_test;

--- a/contract/contracts/hello-world/src/tests/get_group_members_boundary_test.rs
+++ b/contract/contracts/hello-world/src/tests/get_group_members_boundary_test.rs
@@ -1,0 +1,116 @@
+#![cfg(test)]
+
+use crate::test_utils::{
+    create_test_members, deploy_autoshare_contract, deploy_mock_token, mint_tokens,
+};
+use crate::AutoShareContractClient;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Vec};
+use crate::base::types::GroupMember;
+
+fn setup(env: &Env) -> (Address, Address, AutoShareContractClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let contract_id = deploy_autoshare_contract(env, &admin);
+    let client = AutoShareContractClient::new(env, &contract_id);
+    client.initialize_admin(&admin);
+
+    let token = deploy_mock_token(
+        env,
+        &String::from_str(env, "Test Token"),
+        &String::from_str(env, "TEST"),
+    );
+    client.add_supported_token(&token, &admin);
+    (admin, token, client)
+}
+
+fn make_group(
+    env: &Env,
+    client: &AutoShareContractClient,
+    token: &Address,
+    creator: &Address,
+    seed: u8,
+) -> BytesN<32> {
+    let id = BytesN::from_array(env, &[seed; 32]);
+    mint_tokens(env, token, creator, 10_000);
+    client.create(&id, &String::from_str(env, "Test Group"), creator, &1, token);
+    id
+}
+
+#[test]
+fn test_get_group_members_max_capacity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 1);
+
+    // Max capacity is usually 50 as per autoshare_logic.rs
+    let max_members = 50;
+    let mut members: Vec<GroupMember> = Vec::new(&env);
+    for _i in 0..max_members {
+        members.push_back(GroupMember {
+            address: Address::generate(&env),
+            percentage: 2, // 2% * 50 = 100%
+        });
+    }
+
+    client.update_members(&id, &creator, &members);
+    
+    let result = client.get_group_members(&id);
+    assert_eq!(result.len(), 50);
+}
+
+#[test]
+#[should_panic] // GroupNotFound results in panic in client.get(id) which get_group_members uses
+fn test_get_group_members_nonexistent_group() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, _, client) = setup(&env);
+    
+    let ghost_id = BytesN::from_array(&env, &[0xFFu8; 32]);
+    client.get_group_members(&ghost_id);
+}
+
+#[test]
+fn test_get_group_members_after_deactivation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let id = make_group(&env, &client, &token, &creator, 2);
+
+    let members = create_test_members(&env, 2);
+    client.update_members(&id, &creator, &members);
+    
+    client.deactivate_group(&id, &creator);
+    assert_eq!(client.is_group_active(&id), false);
+
+    // Members should still be fetchable
+    let result = client.get_group_members(&id);
+    assert_eq!(result.len(), 2);
+}
+
+#[test]
+fn test_get_group_members_extreme_input() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, token, client) = setup(&env);
+    let creator = Address::generate(&env);
+    
+    // Large ID (handled by type, but good to check)
+    let id = BytesN::from_array(&env, &[0xEEu8; 32]);
+    mint_tokens(&env, &token, &creator, 10_000);
+    client.create(&id, &String::from_str(&env, "Extreme Group"), &creator, &1, &token);
+
+    // One member with 100%
+    let mut members: Vec<GroupMember> = Vec::new(&env);
+    members.push_back(GroupMember {
+        address: Address::generate(&env),
+        percentage: 100,
+    });
+    client.update_members(&id, &creator, &members);
+
+    let result = client.get_group_members(&id);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.get(0).unwrap().percentage, 100);
+}

--- a/contract/contracts/hello-world/src/tests/protocol_fee_boundary_test.rs
+++ b/contract/contracts/hello-world/src/tests/protocol_fee_boundary_test.rs
@@ -1,0 +1,104 @@
+use crate::test_utils::{
+    deploy_autoshare_contract,
+};
+use crate::AutoShareContractClient;
+use soroban_sdk::{testutils::Address as _, Address, Env, testutils::Events, FromVal};
+
+fn setup(env: &Env) -> (Address, AutoShareContractClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let contract_id = deploy_autoshare_contract(env, &admin);
+    let client = AutoShareContractClient::new(env, &contract_id);
+    client.initialize_admin(&admin);
+    (admin, client)
+}
+
+#[test]
+fn test_protocol_fee_initial_state() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    
+    let (fee, recipient) = client.get_protocol_fee();
+    assert_eq!(fee, 0);
+    assert_eq!(recipient, admin); // Default to admin
+}
+
+#[test]
+fn test_set_protocol_fee_admin_only() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let non_admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    env.mock_all_auths();
+    
+    // Set as non-admin should fail
+    let result = client.try_set_protocol_fee(&100, &recipient, &non_admin);
+    assert!(result.is_err());
+
+    // Set as admin should succeed
+    client.set_protocol_fee(&100, &recipient, &admin);
+    let (fee, new_recipient) = client.get_protocol_fee();
+    assert_eq!(fee, 100);
+    assert_eq!(new_recipient, recipient);
+}
+
+#[test]
+fn test_protocol_fee_boundary_values() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    env.mock_all_auths();
+
+    // Max fee 100% (10000 bps)
+    client.set_protocol_fee(&10000, &recipient, &admin);
+    assert_eq!(client.get_protocol_fee().0, 10000);
+
+    // Exceeding 100% should fail
+    let result = client.try_set_protocol_fee(&10001, &recipient, &admin);
+    assert!(result.is_err());
+
+    // Zero fee
+    client.set_protocol_fee(&0, &recipient, &admin);
+    assert_eq!(client.get_protocol_fee().0, 0);
+}
+
+#[test]
+fn test_protocol_fee_read_tracking_event() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    env.mock_all_auths();
+
+    client.set_protocol_fee(&150, &admin, &admin);
+    
+    // Clear previous events
+    let _ = env.events().all();
+
+    // Trigger read
+    client.get_protocol_fee();
+
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        let symbol = soroban_sdk::Symbol::from_val(&env, &e.1.get(0).unwrap());
+        symbol == soroban_sdk::Symbol::new(&env, "protocol_fee_read")
+    });
+    assert!(found, "ProtocolFeeRead event not found");
+}
+
+#[test]
+fn test_protocol_fee_update_event() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    env.mock_all_auths();
+
+    let _ = env.events().all();
+    client.set_protocol_fee(&200, &recipient, &admin);
+
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        let symbol = soroban_sdk::Symbol::from_val(&env, &e.1.get(0).unwrap());
+        symbol == soroban_sdk::Symbol::new(&env, "protocol_fee_updated")
+    });
+    assert!(found, "ProtocolFeeUpdated event not found");
+}


### PR DESCRIPTION
## Overview
This PR resolves four critical issues related to contract security, observability, and documentation. It introduces protocol-level fee management, implements advanced boundary testing for core functions, and adds diagnostic tracking for key read operations.

## Changes

### 🔐 Protocol Fee Management (#294, #293, #290)
- **Implementation**: Added [get_protocol_fee](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Paymesh-stellr/contract/contracts/hello-world/src/autoshare_logic.rs:3296:0-3300:1) and [set_protocol_fee](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Paymesh-stellr/contract/contracts/hello-world/src/autoshare_logic.rs:3302:0-3332:1) to the Soroban contract.
- **Analytics**: Added [ProtocolFeeRead](cci:2://file:///home/nanle/Desktop/OpenSource/drips/Paymesh-stellr/contract/contracts/hello-world/src/base/events.rs:474:0-477:1) events to track function invocations for off-chain analytics as requested.
- **Security**: Integrated robust admin authorization and range validation (max 100%) for fee updates.

### 🧪 Advanced Boundary Testing (#283, #293)
Implemented over 100 lines of new boundary tests covering:
- **Group Members**: Max capacity limits (50), nonexistent group panics, and deactivation behavior.
- **Protocol Fees**: Initial states, boundary values (0-10000 bps), and unauthorized access attempts.
- **Event Verification**: Manual verification of event emission patterns using the Soroban test environment.

### 📚 Documentation (#290)
- Added comprehensive Rustdoc comments to the protocol fee implementation.
- Updated the architectural [README.md](cci:7://file:///home/nanle/Desktop/OpenSource/drips/Paymesh-stellr/contract/README.md:0:0-0:0) with a new "Protocol Configuration" section explaining arguments, events, and panic conditions.

## Verification
Successfully executed the full contract test suite:
- **360 tests passed** (0 failed).
- Verified that [protocol_fee_read](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Paymesh-stellr/contract/contracts/hello-world/src/base/events.rs:479:0-481:1) diagnostic events are properly emitted during read calls.

Closes #283

 Closes #294
 
  Closes #293
  
  Closes #290
