### PR TITLE
feat: implement deposit_funds with event emission (Issue #299)

### DIFF
--- a/contract/contracts/hello-world/src/autoshare_logic.rs
+++ b/contract/contracts/hello-world/src/autoshare_logic.rs
@@ -1,7 +1,8 @@
 use crate::base::errors::Error;
 use crate::base::events::{
     emit_contribution, emit_creator_is_member, emit_distribution, emit_fundraising_cancelled,
-    emit_fundraising_target_updated, emit_funds_deposited, emit_max_members_updated,
+    emit_fundraising_target_updated, emit_funds_deposited, emit_group_members_queried,
+    emit_group_protocol_fee_updated, emit_max_members_updated, emit_member_added,
     emit_member_removed, emit_payment_group_deactivated, emit_usage_fee_updated, AdminTransferred,
     AutoshareCreated, AutoshareUpdated, ContractPaused, ContractUnpaused, FundraisingStarted,
     GroupActivated, GroupDeactivated, GroupDeleted, GroupNameUpdated, GroupOwnershipTransferred,
@@ -40,6 +41,12 @@ pub enum DataKey {
     GroupMembersQueryCount(BytesN<32>),
     ProtocolFee,
     ProtocolFeeRecipient,
+    // Deposit/Treasury tracking (Issue #299)
+    GroupTreasuryBalance(BytesN<32>, Address), // group_id, token
+    GroupDepositHistory(BytesN<32>),           // group_id
+    DepositorHistory(Address),                 // depositor address
+    // Group protocol fee overrides
+    GroupProtocolFee(BytesN<32>),
 }
 
 const DAY_IN_LEDGERS: u32 = 17280;
@@ -840,6 +847,9 @@ pub fn add_member_to_group(
     AutoshareUpdated {
         id: id.clone(),
         updater: caller,
+        name_updated: false,
+        metadata_updated: false,
+        new_creator: None,
     }
     .publish(&env);
 
@@ -1280,55 +1290,6 @@ pub fn get_usage_fee(env: Env) -> u32 {
     result.unwrap_or(10u32)
 }
 
-/// Sets the global protocol fee percentage (0–100). Pass `group_id = None` for the global
-/// default, or `Some(id)` to override the fee for a specific group. Admin only.
-pub fn set_protocol_fee(
-    env: Env,
-    admin: Address,
-    fee_percent: u32,
-    group_id: Option<BytesN<32>>,
-) -> Result<(), Error> {
-    admin.require_auth();
-    require_admin(&env, &admin)?;
-
-    if fee_percent > 100 {
-        return Err(Error::InvalidInput);
-    }
-
-    match group_id {
-        Some(id) => {
-            let key = DataKey::GroupProtocolFee(id);
-            env.storage().persistent().set(&key, &fee_percent);
-            bump_persistent(&env, &key);
-        }
-        None => {
-            let key = DataKey::ProtocolFee;
-            env.storage().persistent().set(&key, &fee_percent);
-            bump_persistent(&env, &key);
-        }
-    }
-
-    Ok(())
-}
-
-/// Returns the effective protocol fee percentage for a group.
-/// Falls back to the global protocol fee if no group-specific override is set.
-pub fn get_protocol_fee(env: Env, group_id: Option<BytesN<32>>) -> u32 {
-    if let Some(id) = group_id {
-        let group_key = DataKey::GroupProtocolFee(id);
-        if let Some(fee) = env.storage().persistent().get::<DataKey, u32>(&group_key) {
-            bump_persistent(&env, &group_key);
-            return fee;
-        }
-    }
-    let global_key = DataKey::ProtocolFee;
-    let result: Option<u32> = env.storage().persistent().get(&global_key);
-    if result.is_some() {
-        bump_persistent(&env, &global_key);
-    }
-    result.unwrap_or(0u32)
-}
-
 pub fn set_max_members(env: Env, admin: Address, max: u32) -> Result<(), Error> {
     admin.require_auth();
     require_admin(&env, &admin)?;
@@ -1376,33 +1337,6 @@ pub fn get_min_contribution(env: Env) -> i128 {
     result.unwrap_or(0i128)
 }
 
-pub fn set_protocol_fee(env: Env, admin: Address, percentage: u32) -> Result<(), Error> {
-    admin.require_auth();
-    require_admin(&env, &admin)?;
-
-    // Percentage must be between 0 and 100
-    if percentage > 100 {
-        return Err(Error::InvalidAmount);
-    }
-
-    let old_fee = get_protocol_fee(env.clone());
-    let key = DataKey::ProtocolFee;
-    env.storage().persistent().set(&key, &percentage);
-    bump_persistent(&env, &key);
-
-    emit_protocol_fee_updated(&env, old_fee, percentage);
-    Ok(())
-}
-
-pub fn get_protocol_fee(env: Env) -> u32 {
-    let key = DataKey::ProtocolFee;
-    let fee: u32 = env.storage().persistent().get(&key).unwrap_or(0);
-    if env.storage().persistent().has(&key) {
-        bump_persistent(&env, &key);
-    }
-    fee
-}
-
 pub fn set_group_protocol_fee(
     env: Env,
     admin: Address,
@@ -1439,7 +1373,8 @@ pub fn get_group_protocol_fee(env: Env, id: BytesN<32>) -> u32 {
         bump_persistent(&env, &key);
         fee.unwrap()
     } else {
-        get_protocol_fee(env)
+        let (fee, _) = get_protocol_fee(env);
+        fee
     }
 }
 
@@ -3579,4 +3514,186 @@ fn get_protocol_recipient_val(env: &Env) -> Address {
         bump_persistent(env, &key);
     }
     recipient
+}
+
+// ============================================================================
+// Deposit Funds Implementation (Issue #299)
+// ============================================================================
+
+/// Deposits funds into a group's treasury for future distributions.
+///
+/// This function allows any user to deposit supported tokens into an active group's
+/// treasury. The deposited amount is transferred from the depositor to the contract
+/// and tracked for analytics and history purposes.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+/// * `id` - The unique identifier of the AutoShare group
+/// * `token` - The token address being deposited
+/// * `amount` - The amount to deposit (must be > 0)
+/// * `depositor` - The address of the depositor (must authorize)
+///
+/// # Events
+///
+/// Emits `FundsDeposited` event with group_id, depositor, token, amount, and new treasury balance.
+///
+/// # Panics
+///
+/// Panics if:
+/// - Amount is zero or negative (InvalidAmount)
+/// - Group does not exist (NotFound)
+/// - Group is inactive (GroupInactive)
+/// - Contract is paused (ContractPaused)
+/// - Token is not supported (UnsupportedToken)
+/// - Token transfer fails
+pub fn deposit_funds(
+    env: Env,
+    id: BytesN<32>,
+    token: Address,
+    amount: i128,
+    depositor: Address,
+) -> Result<(), Error> {
+    // 1. Validate amount
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    // 2. Check contract is not paused
+    if get_paused_status(&env) {
+        return Err(Error::ContractPaused);
+    }
+
+    // 3. Validate group exists and is active
+    let group_key = DataKey::AutoShare(id.clone());
+    if !env.storage().persistent().has(&group_key) {
+        return Err(Error::NotFound);
+    }
+
+    let group: AutoShareDetails = env.storage().persistent().get(&group_key).unwrap();
+    if !group.is_active {
+        return Err(Error::GroupInactive);
+    }
+
+    // 4. Validate token is supported
+    if !is_token_supported(env.clone(), token.clone()) {
+        return Err(Error::UnsupportedToken);
+    }
+
+    // 5. Require depositor authorization
+    depositor.require_auth();
+
+    // 6. Transfer tokens from depositor to contract
+    let token_client = token::Client::new(&env, &token);
+    token_client.transfer(&depositor, &env.current_contract_address(), &amount);
+
+    // 7. Update treasury balance
+    let balance_key = DataKey::GroupTreasuryBalance(id.clone(), token.clone());
+    let current_balance: i128 = env.storage().persistent().get(&balance_key).unwrap_or(0);
+    let new_balance = current_balance + amount;
+    env.storage().persistent().set(&balance_key, &new_balance);
+    bump_persistent(&env, &balance_key);
+
+    // 8. Record deposit in group history
+    let deposit_record = DepositRecord {
+        group_id: id.clone(),
+        depositor: depositor.clone(),
+        token: token.clone(),
+        amount,
+        timestamp: env.ledger().timestamp(),
+    };
+
+    let group_history_key = DataKey::GroupDepositHistory(id.clone());
+    let mut group_history: Vec<DepositRecord> = env
+        .storage()
+        .persistent()
+        .get(&group_history_key)
+        .unwrap_or_else(|| Vec::new(&env));
+    group_history.push_back(deposit_record.clone());
+    env.storage().persistent().set(&group_history_key, &group_history);
+    bump_persistent(&env, &group_history_key);
+
+    // 9. Record deposit in depositor history
+    let depositor_history_key = DataKey::DepositorHistory(depositor.clone());
+    let mut depositor_history: Vec<DepositRecord> = env
+        .storage()
+        .persistent()
+        .get(&depositor_history_key)
+        .unwrap_or_else(|| Vec::new(&env));
+    depositor_history.push_back(deposit_record);
+    env.storage()
+        .persistent()
+        .set(&depositor_history_key, &depositor_history);
+    bump_persistent(&env, &depositor_history_key);
+
+    // 10. Emit FundsDeposited event
+    emit_funds_deposited(&env, id, depositor, token, amount, new_balance);
+
+    Ok(())
+}
+
+/// Returns the treasury balance for a specific group and token.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+/// * `id` - The unique identifier of the AutoShare group
+/// * `token` - The token address to check balance for
+///
+/// # Returns
+///
+/// Returns the current treasury balance (0 if no deposits have been made).
+pub fn get_group_treasury_balance(env: Env, id: BytesN<32>, token: Address) -> i128 {
+    let key = DataKey::GroupTreasuryBalance(id, token);
+    let balance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+    if env.storage().persistent().has(&key) {
+        bump_persistent(&env, &key);
+    }
+    balance
+}
+
+/// Returns all deposit history records for a specific group.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+/// * `id` - The unique identifier of the AutoShare group
+///
+/// # Returns
+///
+/// Returns a vector of all deposit records for the group (empty if no deposits).
+pub fn get_group_deposit_history(env: Env, id: BytesN<32>) -> Vec<DepositRecord> {
+    let key = DataKey::GroupDepositHistory(id);
+    let history: Vec<DepositRecord> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(&env));
+    if env.storage().persistent().has(&key) {
+        bump_persistent(&env, &key);
+    }
+    history
+}
+
+/// Returns all deposit history records for a specific depositor across all groups.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+/// * `depositor` - The address of the depositor
+///
+/// # Returns
+///
+/// Returns a vector of all deposit records by the depositor (empty if no deposits).
+pub fn get_depositor_history(env: Env, depositor: Address) -> Vec<DepositRecord> {
+    let key = DataKey::DepositorHistory(depositor);
+    let history: Vec<DepositRecord> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(&env));
+    if env.storage().persistent().has(&key) {
+        bump_persistent(&env, &key);
+    }
+    history
 }

--- a/contract/contracts/hello-world/src/base/events.rs
+++ b/contract/contracts/hello-world/src/base/events.rs
@@ -477,3 +477,41 @@ pub struct ProtocolFeeRead {
 pub fn emit_protocol_fee_read(env: &Env, fee: u32, recipient: Address) {
     ProtocolFeeRead { fee, recipient }.publish(env);
 }
+
+/// Emitted when get_group_members is queried for analytics tracking.
+#[contractevent]
+#[derive(Clone)]
+pub struct GroupMembersQueried {
+    #[topic]
+    pub group_id: BytesN<32>,
+    pub member_count: u32,
+    pub query_count: u64,
+}
+
+pub fn emit_group_members_queried(env: &Env, group_id: BytesN<32>, member_count: u32, query_count: u64) {
+    GroupMembersQueried {
+        group_id,
+        member_count,
+        query_count,
+    }
+    .publish(env);
+}
+
+/// Emitted when a group-specific protocol fee is updated.
+#[contractevent]
+#[derive(Clone)]
+pub struct GroupProtocolFeeUpdated {
+    #[topic]
+    pub group_id: BytesN<32>,
+    pub old_fee: u32,
+    pub new_fee: u32,
+}
+
+pub fn emit_group_protocol_fee_updated(env: &Env, group_id: BytesN<32>, old_fee: u32, new_fee: u32) {
+    GroupProtocolFeeUpdated {
+        group_id,
+        old_fee,
+        new_fee,
+    }
+    .publish(env);
+}

--- a/contract/contracts/hello-world/src/interfaces/autoshare.rs
+++ b/contract/contracts/hello-world/src/interfaces/autoshare.rs
@@ -243,12 +243,6 @@ pub trait AutoShareTrait {
     /// Returns the current usage fee.
     fn get_usage_fee(env: Env) -> u32;
 
-    /// Sets the protocol fee percentage (admin only).
-    fn set_protocol_fee(env: Env, admin: Address, percentage: u32);
-
-    /// Returns the current global protocol fee percentage.
-    fn get_protocol_fee(env: Env) -> u32;
-
     /// Sets the group-specific protocol fee percentage (admin only).
     fn set_group_protocol_fee(env: Env, admin: Address, id: BytesN<32>, percentage: u32);
 

--- a/contract/contracts/hello-world/src/lib.rs
+++ b/contract/contracts/hello-world/src/lib.rs
@@ -471,22 +471,6 @@ impl AutoShareContract {
         autoshare_logic::get_usage_fee(env)
     }
 
-    /// Sets the protocol fee percentage (0–100). Pass `group_id = None` for the global
-    /// default, or `Some(id)` to set a group-specific override. Admin only.
-    pub fn set_protocol_fee(
-        env: Env,
-        admin: Address,
-        fee_percent: u32,
-        group_id: Option<BytesN<32>>,
-    ) {
-        autoshare_logic::set_protocol_fee(env, admin, fee_percent, group_id).unwrap();
-    }
-
-    /// Returns the effective protocol fee percentage for a group (or the global default).
-    pub fn get_protocol_fee(env: Env, group_id: Option<BytesN<32>>) -> u32 {
-        autoshare_logic::get_protocol_fee(env, group_id)
-    }
-
     /// Sets the maximum number of members per group (admin only).
     pub fn set_max_members(env: Env, admin: Address, max: u32) {
         autoshare_logic::set_max_members(env, admin, max).unwrap();
@@ -495,16 +479,6 @@ impl AutoShareContract {
     /// Returns the current maximum number of members per group.
     pub fn get_max_members(env: Env) -> u32 {
         autoshare_logic::get_max_members(&env)
-    }
-
-    /// Sets the protocol fee percentage (admin only).
-    pub fn set_protocol_fee(env: Env, admin: Address, percentage: u32) {
-        autoshare_logic::set_protocol_fee(env, admin, percentage).unwrap();
-    }
-
-    /// Returns the current global protocol fee percentage.
-    pub fn get_protocol_fee(env: Env) -> u32 {
-        autoshare_logic::get_protocol_fee(env)
     }
 
     /// Sets the group-specific protocol fee percentage (admin only).
@@ -797,6 +771,78 @@ impl AutoShareContract {
     pub fn set_protocol_fee(env: Env, fee: u32, recipient: Address, admin: Address) {
         autoshare_logic::set_protocol_fee(env, fee, recipient, admin).unwrap();
     }
+
+    // ============================================================================
+    // Deposit Funds (Issue #299)
+    // ============================================================================
+
+    /// Deposits funds into a group's treasury for future distributions.
+    ///
+    /// This function allows any user to deposit supported tokens into an active group's
+    /// treasury. The deposited amount is transferred from the depositor to the contract
+    /// and tracked for analytics and history purposes.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `id` - The unique identifier of the AutoShare group
+    /// * `token` - The token address being deposited
+    /// * `amount` - The amount to deposit (must be > 0)
+    /// * `depositor` - The address of the depositor (must authorize)
+    ///
+    /// # Events
+    ///
+    /// Emits `FundsDeposited` event with group_id, depositor, token, amount, and new treasury balance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if validation fails or token transfer fails.
+    pub fn deposit_funds(env: Env, id: BytesN<32>, token: Address, amount: i128, depositor: Address) {
+        autoshare_logic::deposit_funds(env, id, token, amount, depositor).unwrap();
+    }
+
+    /// Returns the treasury balance for a specific group and token.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `id` - The unique identifier of the AutoShare group
+    /// * `token` - The token address to check balance for
+    ///
+    /// # Returns
+    ///
+    /// Returns the current treasury balance (0 if no deposits have been made).
+    pub fn get_group_treasury_balance(env: Env, id: BytesN<32>, token: Address) -> i128 {
+        autoshare_logic::get_group_treasury_balance(env, id, token)
+    }
+
+    /// Returns all deposit history records for a specific group.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `id` - The unique identifier of the AutoShare group
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of all deposit records for the group (empty if no deposits).
+    pub fn get_group_deposit_history(env: Env, id: BytesN<32>) -> Vec<base::types::DepositRecord> {
+        autoshare_logic::get_group_deposit_history(env, id)
+    }
+
+    /// Returns all deposit history records for a specific depositor across all groups.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `depositor` - The address of the depositor
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of all deposit records by the depositor (empty if no deposits).
+    pub fn get_depositor_history(env: Env, depositor: Address) -> Vec<base::types::DepositRecord> {
+        autoshare_logic::get_depositor_history(env, depositor)
+    }
 }
 
 // 3. Link the tests (Requirement: Unit Tests)
@@ -983,3 +1029,7 @@ mod get_group_members_boundary_test;
 #[cfg(test)]
 #[path = "tests/protocol_fee_boundary_test.rs"]
 mod protocol_fee_boundary_test;
+
+#[cfg(test)]
+#[path = "tests/deposit_funds_test.rs"]
+mod deposit_funds_test;


### PR DESCRIPTION
- Add deposit_funds function to deposit tokens into group treasury
- Implement get_group_treasury_balance to query treasury balances
- Add get_group_deposit_history for group deposit tracking
- Add get_depositor_history for depositor-wide tracking
- Emit FundsDeposited event with complete payload for indexing
- Add comprehensive Rustdoc documentation
- Fix duplicate function definitions for protocol_fee
- Add missing event emitters and DataKey variants